### PR TITLE
Release source code for 48.3

### DIFF
--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/CurrencyActions.java
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/CurrencyActions.java
@@ -65,10 +65,17 @@ public class CurrencyActions {
 
                 regionLocales.add(locale);
 
-                final Optional<CurrencyUnit> currency = getCurrencyForLocale(locale);
+                final Optional<CurrencyUnit> maybeCurrency = getCurrencyForLocale(locale);
 
-                if (currency.isPresent() && !currencies.contains(currency.get())) {
-                    currencies.add(currency.get());
+                if (maybeCurrency.isPresent() && !currencies.contains(maybeCurrency.get())) {
+                    final String currencyCode = maybeCurrency.get().getCurrencyCode();
+
+                    // If we have a special default for this currency, override and use it
+                    if (Currency.OVERRIDES.get(currencyCode) != null) {
+                        currencies.add(Currency.OVERRIDES.get(currencyCode));
+                    } else {
+                        currencies.add(maybeCurrency.get());
+                    }
                 }
             }
         }
@@ -94,6 +101,9 @@ public class CurrencyActions {
         return currencies;
     }
 
+    /**
+     * Get default currencies, when we can't reliably detect a region to find its currency.
+     */
     private Set<CurrencyUnit> getDefaultCurrencies() {
 
         final Set<CurrencyUnit> currencies = new HashSet<>();

--- a/android/apollo/src/main/java/io/muun/apollo/domain/model/user/User.java
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/model/user/User.java
@@ -163,6 +163,10 @@ public class User {
      * Get the user's primary currency, if exchange rate is available, BTC otherwise.
      */
     public CurrencyUnit getPrimaryCurrency(ExchangeRateProvider rateProvider) {
+        if (Currency.OVERRIDES.get(primaryCurrency.getCurrencyCode()) != null) {
+            return Currency.OVERRIDES.get(primaryCurrency.getCurrencyCode());
+        }
+
         if (rateProvider.isAvailable(primaryCurrency, Currency.getUnit("BTC").get())) {
             return primaryCurrency;
         } else {

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -81,8 +81,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 30
-        versionCode 802
-        versionName "48.2"
+        versionCode 803
+        versionName "48.3"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/

--- a/android/apolloui/src/androidTest/java/io/muun/apollo/utils/WithMuunInstrumentationHelpers.kt
+++ b/android/apolloui/src/androidTest/java/io/muun/apollo/utils/WithMuunInstrumentationHelpers.kt
@@ -478,6 +478,10 @@ interface WithMuunInstrumentationHelpers : WithMuunEspressoHelpers {
         assertThat(this.isEnabled).isTrue()
     }
 
+    fun UiObject.assertDisabled() {
+        assertThat(this.isEnabled).isFalse()
+    }
+
     fun UiObject.assertEnabledAndClick(): Boolean {
         assertEnabled()
         return click()

--- a/android/apolloui/src/androidTest/java/io/muun/apollo/utils/screens/NewOperationScreen.kt
+++ b/android/apolloui/src/androidTest/java/io/muun/apollo/utils/screens/NewOperationScreen.kt
@@ -33,8 +33,11 @@ class NewOperationScreen(
         id(R.id.total_amount).text.toMoney()
 
     fun waitUntilVisible() {
-        id(R.id.muun_next_step_button).waitForExists(15000)
+        button(R.id.muun_next_step_button).waitForExists(15000)
     }
+
+    fun assertSubmitIsDisabled() =
+        button(R.id.muun_next_step_button).assertDisabled()
 
     fun fillForm(amount: MonetaryAmount?, description: String?) {
 

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/activity/extension/ErrorFragmentExtension.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/activity/extension/ErrorFragmentExtension.kt
@@ -9,6 +9,7 @@ import io.muun.apollo.presentation.ui.base.di.PerActivity
 import io.muun.apollo.presentation.ui.fragments.error.ErrorFragment
 import io.muun.apollo.presentation.ui.fragments.error.ErrorFragmentDelegate
 import io.muun.apollo.presentation.ui.fragments.error.ErrorViewModel
+import io.muun.apollo.presentation.ui.utils.safelyCommitNow
 import io.muun.common.utils.CollectionUtils
 import io.muun.common.utils.Preconditions
 import javax.inject.Inject
@@ -72,14 +73,5 @@ class ErrorFragmentExtension @Inject constructor() : ActivityExtension() {
             .beginTransaction()
             .replace(android.R.id.content, fragment, TAG)
             .safelyCommitNow(activity)
-    }
-
-    private fun FragmentTransaction.safelyCommitNow(activity: ExtensibleActivity) {
-        if (!activity.isFinishing && !activity.isDestroyed) {
-            val fragmentManager = activity.supportFragmentManager
-            if (!fragmentManager.isDestroyed && !fragmentManager.isStateSaved) {
-                commitNow()
-            }
-        }
     }
 }

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/base/SingleFragmentActivity.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/base/SingleFragmentActivity.java
@@ -4,6 +4,7 @@ import io.muun.apollo.presentation.ui.activity.extension.ErrorFragmentExtension;
 import io.muun.apollo.presentation.ui.bundler.StringListBundler;
 import io.muun.apollo.presentation.ui.fragments.error.ErrorViewModel;
 import io.muun.apollo.presentation.ui.listener.OnBackPressedListener;
+import io.muun.apollo.presentation.ui.utils.ExtensionsKt;
 import io.muun.apollo.presentation.ui.view.MuunHeader;
 import io.muun.common.utils.Preconditions;
 
@@ -41,6 +42,9 @@ public abstract class SingleFragmentActivity<PresenterT extends Presenter>
         return 0; // valid, signals the Activity will manage Fragments without helpers
     }
 
+    /**
+     * Get Muun header (action/toolbar wrapper).
+     */
     public abstract MuunHeader getHeader();
 
     @Override
@@ -87,7 +91,7 @@ public abstract class SingleFragmentActivity<PresenterT extends Presenter>
     @Override
     public void replaceFragmentNow(@NotNull Fragment fragment) {
         final FragmentTransaction transaction = getFragmentTx(fragment);
-        transaction.commitNow();
+        ExtensionsKt.safelyCommitNow(transaction, this);
     }
 
     @NonNull
@@ -221,10 +225,16 @@ public abstract class SingleFragmentActivity<PresenterT extends Presenter>
         this.backPressedListener = listener;
     }
 
+    /**
+     * Show error widget/screen.
+     */
     public void showError(ErrorViewModel viewModel) {
         errorFragmentExtension.showError(viewModel);
     }
 
+    /**
+     * Dismiss/Hide error widget/screen.
+     */
     public void hideError() {
         errorFragmentExtension.hideError();
     }

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOpExtensions.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOpExtensions.kt
@@ -82,5 +82,8 @@ fun PaymentContext.buildExchangeRateProvider(): ExchangeRateProvider {
     )
 }
 
+fun PaymentContext.outpoints(): List<String> =
+    nextTransactionSize.outpoints?.split("\n")?.filterNot { it.isEmpty() } ?: listOf()
+
 fun estimateTimeInMs(numBlocks: Int) =
     BlockHelpers.timeInSecsForBlocksWithCertainty(numBlocks, CONF_CERTAINTY).toLong() * 1000

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationView.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationView.kt
@@ -1,27 +1,20 @@
 package io.muun.apollo.presentation.ui.new_operation
 
-import io.muun.apollo.domain.model.*
+import io.muun.apollo.domain.model.BitcoinUnit
+import io.muun.apollo.domain.model.Contact
 import io.muun.apollo.domain.model.SubmarineSwap
 import io.muun.apollo.presentation.ui.base.BaseView
-import newop.*
+import newop.AmountInfo
+import newop.EnterAmountState
+import newop.EnterDescriptionState
+import newop.Resolved
+import newop.Validated
 
 interface NewOperationView : BaseView {
 
     fun setBitcoinUnit(bitcoinUnit: BitcoinUnit)
 
-    fun setForm(form: NewOperationForm)
-
-    fun setPaymentAnalysis(analysis: PaymentAnalysis)
-
     fun setLoading(isLoading: Boolean)
-
-    fun setConnectedToNetwork(isConnected: Boolean)
-
-    fun editFee(paymentRequest: PaymentRequest)
-
-    fun editFeeManually(paymentRequest: PaymentRequest)
-
-    fun confirmFee(selectedFeeRate: Double)
 
     fun showErrorScreen(type: NewOperationErrorType)
 

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/utils/Extensions.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/utils/Extensions.kt
@@ -21,8 +21,10 @@ import androidx.annotation.*
 import androidx.core.content.ContextCompat
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
 import io.muun.apollo.R
 import io.muun.apollo.domain.utils.locale
+import io.muun.apollo.presentation.ui.base.ExtensibleActivity
 import timber.log.Timber
 import java.util.*
 
@@ -243,3 +245,12 @@ fun TextView.setStyledText(@StringRes resId: Int, onLinkClick: (String) -> Unit 
 
 fun PackageManager.hasAppInstalled(intent: Intent) =
     queryIntentActivities(intent, 0).size != 0
+
+fun FragmentTransaction.safelyCommitNow(activity: ExtensibleActivity) {
+    if (!activity.isFinishing && !activity.isDestroyed) {
+        val fragmentManager = activity.supportFragmentManager
+        if (!fragmentManager.isDestroyed && !fragmentManager.isStateSaved) {
+            commitNow()
+        }
+    }
+}

--- a/android/apolloui/src/main/res/values/strings.xml
+++ b/android/apolloui/src/main/res/values/strings.xml
@@ -1148,7 +1148,7 @@
 
     <string name="sc_task_header_0">Your wallet is not backed up</string>
     <string name="sc_task_header_1">Your wallet has a basic backup</string>
-    <string name="sc_task_header_2">Your\'re one step away from a complete setup</string>
+    <string name="sc_task_header_2">You\'re one step away from a complete setup</string>
     <string name="sc_task_header_3">You completed your setup</string>
 
     <!-- Emergency Kit -->

--- a/common/src/main/java/io/muun/common/model/Currency.java
+++ b/common/src/main/java/io/muun/common/model/Currency.java
@@ -16,7 +16,14 @@ public class Currency {
 
     public static final Map<String, Currency> CURRENCIES;
 
+    // These are most likely known currencies for which we don't have an exchange rate. This exists
+    // so we can build better error reports when something goes wrong (e.g a currency/exchange rate
+    // for a currency, disappears).
     public static final Map<String, Currency> NOT_SUPPORTED_BY_HOUSTON = new HashMap<>();
+
+    // We have an absolute default currency (BTC), but for some special case, we might want to
+    // override/default to another currency.
+    public static final Map<String, CurrencyUnit> OVERRIDES = new HashMap<>();
 
     static {
         CURRENCIES = new HashMap<>();
@@ -211,6 +218,9 @@ public class Currency {
         for (Currency value : NOT_SUPPORTED_BY_HOUSTON.values()) {
             load(value);
         }
+
+        // For Salvadoran Colon (deprecated, not longer used), default to USD
+        OVERRIDES.put("SVC", getUnit("USD").get());
     }
 
     private static void load(Currency currency) {

--- a/libwallet/fees/fees.go
+++ b/libwallet/fees/fees.go
@@ -75,10 +75,6 @@ func (p *FundingOutputPolicies) MinFundingAmount(paymentAmount, lightningFee btc
 }
 
 func (p *FundingOutputPolicies) FundingOutputAmount(paymentAmount, lightningFee btcutil.Amount) btcutil.Amount {
-	if p.DebtType(paymentAmount, lightningFee) == DebtTypeLend {
-		return 0
-	}
-
 	minAmount := p.MinFundingAmount(paymentAmount, lightningFee)
 	if minAmount < dustThreshold {
 		return dustThreshold
@@ -87,10 +83,6 @@ func (p *FundingOutputPolicies) FundingOutputAmount(paymentAmount, lightningFee 
 }
 
 func (p *FundingOutputPolicies) FundingOutputPadding(paymentAmount, lightningFee btcutil.Amount) btcutil.Amount {
-	if p.DebtType(paymentAmount, lightningFee) == DebtTypeLend {
-		return 0
-	}
-
 	minAmount := p.MinFundingAmount(paymentAmount, lightningFee)
 	outputAmount := p.FundingOutputAmount(paymentAmount, lightningFee)
 	return outputAmount - minAmount

--- a/libwallet/fees/fees_test.go
+++ b/libwallet/fees/fees_test.go
@@ -159,7 +159,7 @@ func TestComputeSwapFees(t *testing.T) {
 			},
 			expected: &SwapFees{
 				RoutingFee:          10,
-				OutputPadding:       0,
+				OutputPadding:       486,
 				DebtType:            DebtTypeLend,
 				DebtAmount:          60,
 				OutputAmount:        0,

--- a/libwallet/newop/nts.go
+++ b/libwallet/newop/nts.go
@@ -26,9 +26,12 @@ func (w *NextTransactionSize) AddSizeForAmount(item *SizeForAmount) {
 
 func (w *NextTransactionSize) GetOutpoints() string {
 	var sb strings.Builder
-	for _, sizeForAmount := range w.SizeProgression {
+	for i, sizeForAmount := range w.SizeProgression {
 		sb.WriteString(sizeForAmount.Outpoint)
-		sb.WriteRune('\n')
+		if i != len(w.SizeProgression)-1 { // avoid trailing \n at the end
+			sb.WriteRune('\n')
+		}
+
 	}
 	return sb.String()
 }

--- a/libwallet/operation/payment_analyzer_test.go
+++ b/libwallet/operation/payment_analyzer_test.go
@@ -395,6 +395,29 @@ func TestAnalyzeOnChain(t *testing.T) {
 				TotalInSat:  2000,
 			},
 		},
+		{
+			desc: "unpayable using TFFA because amount < DUST",
+			nts: &NextTransactionSize{
+				SizeProgression: []SizeForAmount{
+					{
+						AmountInSat: 10_000,
+						SizeInVByte: 240,
+					},
+				},
+				ExpectedDebtInSat: 7400,
+			},
+			payment: &PaymentToAddress{
+				TakeFeeFromAmount:     true,
+				AmountInSat:           2600,
+				FeeRateInSatsPerVByte: 10,
+			},
+			expected: &PaymentAnalysis{
+				Status:      AnalysisStatusUnpayable,
+				AmountInSat: 200,
+				FeeInSat:    2400,
+				TotalInSat:  2600,
+			},
+		},
 	}
 
 	for _, tC := range testCases {


### PR DESCRIPTION
- CHANGED improved send payment flow reliablity by fixing a Fragment lifecycle issue
- FIXED visual glitch while waiting for bip72 uris to load
- FIXED set correct textcolor for amount input after useAllFunds + back
- FIXED filter empty outpoints strings when submitting a payment to Houston
- FIXED UI issues with tricky send payment case where useAllFunds ends up with amount < DUST
- FIXED typo in english string text, shout out to @BBlackwo