### PR TITLE
Release source code for 49.1

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,12 +6,33 @@ follow [https://changelog.md/](https://changelog.md/) guidelines.
 
 ## [Unreleased]
 
+
+## [49.1] - 2022-03-17
+
+### FIXED
+- Bug when fetching legacy Contact model after SQLDelight upgrade (on 49)
+- Use of Math.toIntExact() which isn't supported on lower api levels (introduced in SQLDelight
+upgrade)
+- MuunAmountInput handling of SATs (currencies without decimals)
+- Incorrect handling of changeCurrency and useAllFunds in send flow, introduced in our send payment
+flow rewrite (48.2)
+- Minor copy change when copying a LN payment hash to clipboard
+
 ## [49] - 2022-03-16
 
 ### ADDED
 - Option to select SAT as input currency for receive and send screens' amount input
 - Extra metadata for rare crash scenario
 - Multiple route hints support in our invoices
+
+### CHANGED
+- Upgrade gradle to 7.3.3 to support JDK17 (ARM support)
+- Upgrade AGP to 7.0.4 for gradle 7.3 compat
+- Upgrade SQDelight to 1.5.3 for gradle 7.3 compat (hughe refactor and rework of data layer)
+- Upgrade Kotlin to 1.6.10 for gradle 7.3 compat
+- Upgrade Dagger to 2.40.5 for gradle 7.3 compat
+- Upgrade checkstyle to 9.2.1
+- Make libwallet it's own gradle project to work nicely with AndroidStudio
 
 ### FIXED
 - Show new outgoing operation badge animation when using deeplink + process death/app not started

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/contact/ContactDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/contact/ContactDao.java
@@ -105,8 +105,8 @@ public class ContactDao extends HoustonIdDao<Contact> {
                         lastName,
                         profilePictureUrl
                 ),
-                Math.toIntExact(maxAddressVersion),
-                PublicKey.deserializeFromBase58(publicKeyPath, publicKeyPath),
+                (int) maxAddressVersion,
+                PublicKey.deserializeFromBase58(publicKeyPath, serializedPublicKey),
                 cosigningPublicKey,
                 lastDerivationIndex
         );

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -80,8 +80,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 30
-        versionCode 900
-        versionName "49"
+        versionCode 901
+        versionName "49.1"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/

--- a/android/apolloui/src/main/AndroidManifest.xml
+++ b/android/apolloui/src/main/AndroidManifest.xml
@@ -363,8 +363,8 @@
         </provider>
 
         <!--
-            Disable WorkManagerInitializer to avoid auto workmanager initialization (use custom). See:
-            https://developer.android.com/topic/libraries/architecture/workmanager/advanced/custom-configuration
+         Disable WorkManagerInitializer to avoid auto workmanager initialization (use custom). See:
+         https://developer.android.com/topic/libraries/architecture/workmanager/advanced/custom-configuration
         -->
         <provider
                 android:name="androidx.work.impl.WorkManagerInitializer"

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/model/text_decoration/MoneyDecoration.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/model/text_decoration/MoneyDecoration.java
@@ -110,11 +110,10 @@ public class MoneyDecoration implements DecorationTransformation {
                 s.replace(indexOfDecimalComma, indexOfDecimalComma + decimalsCount + 1, "");
                 target.setSelection(target.getSelectionStart() - 1 - decimalsCount);
             }
-            target.setText(s);
-            return;
+        } else {
+            // Android Supreme localization bug only happens when dealing with decimal separator
+            handleAndroidSupremeLocalizationBug(s, target);
         }
-
-        handleAndroidSupremeLocalizationBug(s, target);
 
         removeExtraDigitIfDeletingGroupingSeparator(s, target);
         cleanLeadingZeros(s, target);
@@ -224,7 +223,7 @@ public class MoneyDecoration implements DecorationTransformation {
      * </p>
      */
     private void handleAndroidSupremeLocalizationBug(StringBuilder s, DecorationHandler handler) {
-        if (decimalSeparator != '.') {
+        if (decimalSeparator != '.' && maxFractionalDigits != 0) {
 
             replace(s, start, start + after, '.', decimalSeparator);
 

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/fragments/home/HomeFragment.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/fragments/home/HomeFragment.kt
@@ -208,20 +208,12 @@ class HomeFragment: SingleFragment<HomePresenter>(), HomeView {
         balanceView.setBalance(homeState)
         setChevronAnimation(homeState.utxoSetState)
 
-        // We want one of the cards to "occupy space" (aka be invisible not gone) to avoid visual
-        // jumps/glitches
-        taprootCard.visibility = View.GONE
-        securityCenterCard.visibility = View.INVISIBLE
-
-        blockClock.visibility = View.GONE
-
         // Due to (complex) business logic reasons, only 1 of these cards is currently displayed
         var displayedMuunHomeCard: MuunHomeCard? = null
-        val taprootStatus = homeState.taprootFeatureStatus
         if (!homeState.user.isRecoverable) {
             displayedMuunHomeCard = securityCenterCard
 
-        } else when (taprootStatus) {
+        } else when (homeState.taprootFeatureStatus) {
             UserActivatedFeatureStatus.OFF -> { } // Do nothing
             UserActivatedFeatureStatus.CAN_PREACTIVATE -> displayedMuunHomeCard = taprootCard
             UserActivatedFeatureStatus.CAN_ACTIVATE -> displayedMuunHomeCard = taprootCard
@@ -232,12 +224,16 @@ class HomeFragment: SingleFragment<HomePresenter>(), HomeView {
 
         blockClock.value = homeState.blocksToTaproot
 
-        displayedMuunHomeCard?.let {
-            it.visibility = View.VISIBLE
-            if (it == taprootCard) {
-                // Avoid having 2x height when taprootCard is shown (see visual jump comment above)
+        if (displayedMuunHomeCard != null) {
+            displayedMuunHomeCard.visibility = View.VISIBLE
+            if (displayedMuunHomeCard == taprootCard) {
                 securityCenterCard.visibility = View.GONE
+            } else {
+                taprootCard.visibility = View.GONE
             }
+        } else {
+            securityCenterCard.visibility = View.GONE
+            taprootCard.visibility = View.GONE
         }
     }
 

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/home/HomeActivity.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/home/HomeActivity.java
@@ -115,20 +115,19 @@ public class HomeActivity extends SingleFragmentActivity<HomePresenter>
 
         bottomNav.setOnNavigationItemSelectedListener(item -> {
 
-                    final Bundle bundle = new Bundle();
+            final Bundle bundle = new Bundle();
 
-                    if (item.getItemId() == R.id.security_center_fragment) {
-                        final SecurityCenterFragmentArgs args = new SecurityCenterFragmentArgs
-                                .Builder(SECURITY_CENTER_ORIGIN.SHIELD_BUTTON)
-                                .build();
+            if (item.getItemId() == R.id.security_center_fragment) {
+                final SecurityCenterFragmentArgs args = new SecurityCenterFragmentArgs
+                        .Builder(SECURITY_CENTER_ORIGIN.SHIELD_BUTTON)
+                        .build();
 
-                        bundle.putAll(args.toBundle());
-                    }
+                bundle.putAll(args.toBundle());
+            }
 
-                    navigateToItem(item.getItemId(), bundle);
-                    return true;
-                }
-        );
+            navigateToItem(item.getItemId(), bundle);
+            return true;
+        });
         bottomNav.setOnNavigationItemReselectedListener(item -> {
             // do nothing here, it will prevent recreating same fragment
         });

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/home/HomePresenter.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/home/HomePresenter.java
@@ -88,6 +88,10 @@ public class HomePresenter extends BasePresenter<HomeView> implements HomeParent
         fetchRealTimeData.runForced();
     }
 
+    /**
+     * Call to report activity was destroyed.
+     * TODO: this should have a base presenter method associated
+     */
     public void onActivityDestroyed() {
         operationsCache.stop();
     }
@@ -147,10 +151,16 @@ public class HomePresenter extends BasePresenter<HomeView> implements HomeParent
         navigator.navigateToOperations((Activity) view);
     }
 
+    /**
+     * Navigate to send feedbback screen.
+     */
     public void navigateToSendFeedbackScreen() {
         navigator.navigateToSendGenericFeedback(getContext());
     }
 
+    /**
+     * Avoid showing taproot celebration again.
+     */
     public void reportTaprootCelebrationShown() {
         userSel.setPendingTaprootCelebration(false);
     }

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationActivity.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationActivity.kt
@@ -346,10 +346,10 @@ class NewOperationActivity : SingleFragmentActivity<NewOperationPresenter>(), Ne
 
         val paymentContext = state.resolved.paymentContext
         amountInput.setExchangeRateProvider(paymentContext.buildExchangeRateProvider())
-        amountInput.setOnChangeListener { amount: MonetaryAmount ->
+        amountInput.setOnChangeListener { oldAmount: MonetaryAmount, newAmount: MonetaryAmount ->
             amountInput.setAmountError(false)
             actionButton.isEnabled = true
-            presenter.updateAmount(amount, state)
+            presenter.updateAmount(oldAmount, newAmount, state)
         }
 
         useAllFundsView.isEnabled = !balance.isZero

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationPresenter.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/new_operation/NewOperationPresenter.kt
@@ -269,15 +269,15 @@ class NewOperationPresenter @Inject constructor(
         return true
     }
 
-    fun updateAmount(amount: MonetaryAmount, state: EnterAmountState) {
+    fun updateAmount(oldAmount: MonetaryAmount, newAmount: MonetaryAmount, state: EnterAmountState) {
 
         // This is our way of detecting a currency change. Since the feature is abstracted into
         // MuunAmountInput and the exposed API reports the new amount.
-        if (amount.currency.currencyCode != state.amount.inInputCurrency.currency) {
-            state.changeCurrency(amount.currency.currencyCode)
+        if (newAmount.currency.currencyCode != state.amount.inInputCurrency.currency) {
+            state.changeCurrencyWithAmount(newAmount.currency.currencyCode, oldAmount.toLibwallet())
         }
 
-        if (!state.partialValidate(amount.toLibwallet())) {
+        if (!state.partialValidate(newAmount.toLibwallet())) {
             view.setAmountInputError()
         }
     }

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/operation_detail/OperationDetailActivity.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/operation_detail/OperationDetailActivity.java
@@ -285,7 +285,7 @@ public class OperationDetailActivity extends BaseActivity<OperationDetailPresent
         swapPaymentHashItem.setVisibility(
                 !TextUtils.isEmpty(paymentHash) ? View.VISIBLE : View.GONE
         );
-        swapPaymentHashItem.setOnIconClickListener(view -> onCopyPreimageToClipboard(paymentHash));
+        swapPaymentHashItem.setOnIconClickListener(v -> onCopyPaymentHashToClipboard(paymentHash));
 
         final String preimage = operation.getPreimage();
         swapPreimageItem.setDescription(preimage);
@@ -348,6 +348,11 @@ public class OperationDetailActivity extends BaseActivity<OperationDetailPresent
 
     private void onCopyPreimageToClipboard(String preimage) {
         presenter.copySwapPreimageToClipboard(preimage);
+        showTextToast(getString(R.string.operation_detail_preimage_copied));
+    }
+
+    private void onCopyPaymentHashToClipboard(String paymentHash) {
+        presenter.copySwapPreimageToClipboard(paymentHash);
         showTextToast(getString(R.string.operation_detail_preimage_copied));
     }
 

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/select_amount/SelectAmountActivity.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/select_amount/SelectAmountActivity.kt
@@ -111,7 +111,7 @@ class SelectAmountActivity : BaseActivity<SelectAmountPresenter>(), SelectAmount
 
     override fun setExchangeRateProvider(exchangeRateProvider: ExchangeRateProvider) {
         amountInput.setExchangeRateProvider(exchangeRateProvider)
-        amountInput.setOnChangeListener(this::onAmountChange)
+        amountInput.setOnChangeListener { _, newAmount -> onAmountChange(newAmount) }
         amountInput.isEnabled = true
         amountInput.requestFocusInput()
     }

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/MuunAmountInput.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/MuunAmountInput.java
@@ -46,9 +46,9 @@ public class MuunAmountInput extends MuunView {
 
         /**
          * This method is called to notify you that the amount in this input has changed. The
-         * param value holds the new amount.
+         * param values hold the old and the new amount.
          */
-        void onChange(MonetaryAmount value);
+        void onChange(MonetaryAmount oldValue, MonetaryAmount newValue);
     }
 
     static final ViewProps<MuunAmountInput> viewProps
@@ -104,7 +104,7 @@ public class MuunAmountInput extends MuunView {
     private DecimalFormatSymbols symbols;
 
     private boolean isMakingInternalChange;
-    private boolean isCurrentyChangingCurrency;
+    private boolean isCurrentlyChangingCurrency;
 
     public MuunAmountInput(Context context) {
         super(context);
@@ -277,16 +277,17 @@ public class MuunAmountInput extends MuunView {
             newValue = newValue.divide(BitcoinUtils.SATOSHIS_PER_BITCOIN);
         }
 
+        final MonetaryAmount oldValue = value;
         value = newValue;
 
         // Once we start typing, text should have this color, unless overruled by setAmountError
         inputAmount.setTextColor(normalNumberColor);
 
-        if (!isCurrentyChangingCurrency) {
+        if (!isCurrentlyChangingCurrency) {
             valueBeforeCurrencyChange = newValue;
         }
 
-        notifyChange();
+        notifyChange(oldValue, newValue);
     }
 
     private void onCurrencyInputChange(String newCode) {
@@ -309,17 +310,18 @@ public class MuunAmountInput extends MuunView {
             newValue = Money.of(value.getNumber(), newCode);
         }
 
+        final MonetaryAmount oldValue = value;
         value = newValue;
 
         adjustFractionalDigits();
         updateCurrencyCodeText();
         updateAmountText(true);
-        notifyChange();
+        notifyChange(oldValue, newValue);
     }
 
-    private void notifyChange() {
+    private void notifyChange(MonetaryAmount oldValue, MonetaryAmount newValue) {
         if (onChangeListener != null) {
-            onChangeListener.onChange(value);
+            onChangeListener.onChange(oldValue, newValue);
         }
     }
 
@@ -352,7 +354,7 @@ public class MuunAmountInput extends MuunView {
 
     private void updateAmountText(boolean isDueToCurrencyChange) {
         isMakingInternalChange = true;
-        isCurrentyChangingCurrency = isDueToCurrencyChange;
+        isCurrentlyChangingCurrency = isDueToCurrencyChange;
 
         if (value.isPositive()) {
             final String text = MoneyHelper.formatInputMonetaryAmount(
@@ -372,7 +374,7 @@ public class MuunAmountInput extends MuunView {
             inputAmount.setText("");
         }
 
-        isCurrentyChangingCurrency = false;
+        isCurrentlyChangingCurrency = false;
         isMakingInternalChange = false;
     }
 

--- a/android/apolloui/src/main/res/layout/fragment_home.xml
+++ b/android/apolloui/src/main/res/layout/fragment_home.xml
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="32dp"
                 android:layout_marginBottom="64dp"
-                android:visibility="invisible"
+                android:visibility="gone"
                 tools:visibility="visible" />
 
         <io.muun.apollo.presentation.ui.view.BlockClock

--- a/android/apolloui/src/main/res/values-es/strings.xml
+++ b/android/apolloui/src/main/res/values-es/strings.xml
@@ -142,7 +142,8 @@
         Esta factura no incluye un monto
     </string>
     <string name="error_op_invoice_invalid_amount_desc">
-        Por el momento, sólo se puede pagar a facturas que incluyan un monto. Por favor, crea o solicita una nueva.
+        Por el momento, sólo se puede pagar a facturas que incluyan un monto. Por favor,
+        crea o solicita una nueva.
     </string>
 
     <string name="error_op_invoice_invalid_title">No es posible pagar esta factura</string>
@@ -294,6 +295,9 @@
     <string name="operation_detail_invoice_copied">Factura copiada al portapapeles</string>
     <string name="operation_detail_preimage_copied">
         Preimagen del pago copiada al portapapeles
+    </string>
+    <string name="operation_detail_payment_hash_copied">
+        Hash del pago copiado al portapapeles
     </string>
     <string name="operation_detail_txid_copied">
         Identificador copiado al portapapeles
@@ -1382,10 +1386,10 @@
     </string>
     <string name="rbf_notice_banner_title">¿Cómo se puede cancelar esta transacción?</string>
     <string name="rbf_notice_banner_desc">
-        Esta transacción tiene RBF (replace-by-fee) activado. RBF le permite al remitente incrementar
-        la comisión original para una confirmación más rápida, pero también puede usarlo para
-        cancelar la transacción. A menos que conozcas y confíes en el remitente, considéralo
-        un riesgo hasta que se confirme la transacción.
+        Esta transacción tiene RBF (replace-by-fee) activado. RBF le permite al remitente
+        incrementar la comisión original para una confirmación más rápida, pero también puede
+        usarlo para cancelar la transacción. A menos que conozcas y confíes en el remitente,
+        considéralo un riesgo hasta que se confirme la transacción.
     </string>
 
     <string name="turbo_channels">Turbo channels</string>

--- a/android/apolloui/src/main/res/values/strings.xml
+++ b/android/apolloui/src/main/res/values/strings.xml
@@ -146,7 +146,8 @@
         This invoice doesn\’t include an amount
     </string>
     <string name="error_op_invoice_invalid_amount_desc">
-        At the moment, you can only pay to invoices that include an amount. Please, create or request a new one.
+        At the moment, you can only pay to invoices that include an amount. Please, create or
+        request a new one.
     </string>
 
     <string name="error_op_invoice_invalid_title">Unable to pay this invoice</string>
@@ -290,6 +291,7 @@
     </string>
     <string name="operation_detail_invoice_copied">Invoice copied to clipboard</string>
     <string name="operation_detail_preimage_copied">Payment preimage copied to clipboard</string>
+    <string name="operation_detail_payment_hash_copied">Payment hash copied to clipboard</string>
     <string name="operation_detail_txid_copied">Transaction ID copied to clipboard</string>
     <string name="operation_detail_amount_copied">Amount copied to clipboard</string>
     <string name="operation_detail_fee_copied">Network fee copied to clipboard</string>
@@ -1333,13 +1335,14 @@
     <string name="rbf_notice_banner_title">How can this transaction be canceled?</string>
     <string name="rbf_notice_banner_desc">
         This transaction has RBF (replace-by-fee) enabled. RBF allows the sender to raise the
-        original fee for faster confirmation, but they can also use it to cancel the transaction. Unless
-        you know and trust the sender, consider it a risk until the transaction is confirmed.
+        original fee for faster confirmation, but they can also use it to cancel the transaction.
+        Unless you know and trust the sender, consider it a risk until the transaction is confirmed.
     </string>
 
     <string name="turbo_channels">Turbo channels</string>
     <string name="turbo_channels_learn_more">
-        <annotation link="https://blog.muun.com/turbo-channels/">Learn more</annotation> about the trade-offs of turbo channels.
+        <annotation link="https://blog.muun.com/turbo-channels/">Learn more</annotation> about the
+        trade-offs of turbo channels.
     </string>
     <string name="turbo_channels_disable_title">Disable turbo channels?</string>
     <string name="turbo_channels_disable_message">

--- a/android/apolloui/src/test/java/io/muun/apollo/presentation/model/text_decoration/MoneyDecorationTest.kt
+++ b/android/apolloui/src/test/java/io/muun/apollo/presentation/model/text_decoration/MoneyDecorationTest.kt
@@ -138,12 +138,20 @@ class MoneyDecorationTest {
 
             Given(it, "|123", 0).add(".").expect("|123")
 
+            // Test input initializes with some amount
+
+            Given(it, "|", 0).add("0").expect("0|")
+
+            Given(it, "0|", 0).add("0").expect("0|")
+
+            Given(it, "|", 0).add("2000").expect("2_000|")
+
             // This is kindof a benevolent, simple paste
-            Given(it, "44|", 0).add("123.123").expect("44123|")
+            Given(it, "44|", 0).add("123.123").expect("44_123|")
 
-            Given(it, "4|4", 0).add("123.123").expect("4123|4")
+            Given(it, "4|4", 0).add("123.123").expect("41_23|4")
 
-            Given(it, "|44", 0).add("123.123").expect("123|44")
+            Given(it, "|44", 0).add("123.123").expect("12_3|44")
 
             // TODO test paste
         }

--- a/libwallet/newop/context.go
+++ b/libwallet/newop/context.go
@@ -21,10 +21,11 @@ func (c *PaymentContext) toBitcoinAmount(sats int64, inputCurrency string) *Bitc
 		NewMonetaryAmountFromSatoshis(sats),
 		inputCurrency,
 	)
-	return amount.toBitcoinAmount(
-		c.ExchangeRateWindow,
-		c.PrimaryCurrency,
-	)
+	return &BitcoinAmount{
+		InSat:             sats,
+		InInputCurrency:   amount,
+		InPrimaryCurrency: c.ExchangeRateWindow.convert(amount, c.PrimaryCurrency),
+	}
 }
 
 func newPaymentAnalyzer(context *PaymentContext) *operation.PaymentAnalyzer {


### PR DESCRIPTION
## [49.1] - 2022-03-17

### FIXED
- Bug when fetching legacy Contact model after SQLDelight upgrade (on 49)
- Use of Math.toIntExact() which isn't supported on lower api levels (introduced in SQLDelight
upgrade)
- MuunAmountInput handling of SATs (currencies without decimals)
- Incorrect handling of changeCurrency and useAllFunds in send flow, introduced in our send payment
flow rewrite (48.2)
- Minor copy change when copying a LN payment hash to clipboard