### PR TITLE
Apollo: Release source code for 49.5

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,6 +6,21 @@ follow [https://changelog.md/](https://changelog.md/) guidelines.
 
 ## [Unreleased]
 
+## [49.5] - 2022-06-02
+
+### CHANGED
+- Upgrade Firebase dependencies to start using BOM (Bill Of Materials). firebase-bom:30.1.0
+- Upgrade Firebase Messaging as part of firebase-bom:30.1.0
+- Upgrade Firebase Crashlytics as part of firebase-bom:30.1.0
+- Upgrade Firebase Analtyics as part of firebase-bom:30.1.0
+- Upgrade Google Services Gradle Plugin to 4.3.10
+- Changed splash screen english copy
+- Increased FcmToken fetch timeout and add extra retry to improve reliability in Fcm Token registration
+
+### FIXED
+- Removed extra query param requestId for lnurl withdraw requests to avoid errors with certain
+LNURL service providers (e.g ln.cash)
+
 ## [49.4] - 2022-05-23
 
 ### CHANGED

--- a/android/apollo/build.gradle
+++ b/android/apollo/build.gradle
@@ -105,17 +105,22 @@ dependencies {
     api 'org.zalando:jackson-datatype-money:0.12.0'
 
     // Firebase:
-    api 'com.google.firebase:firebase-messaging:17.3.4'
+    // Import the Firebase BoM
+    api platform('com.google.firebase:firebase-bom:30.1.0')
+    // When using the BoM, you don't specify versions in Firebase library dependencies
+
+    // Push Notifications:
+    api 'com.google.firebase:firebase-messaging'
+    // Debugging:
+    api 'com.google.firebase:firebase-crashlytics'
+    // Analytics: Enhance Crashlytics experience (real time crash-free users + breadcrumbs)
+    api 'com.google.firebase:firebase-analytics'
+
 
     // WorkManager: (see https://github.com/muun/muun/issues/5895)
     // Guide: https://developer.android.com/topic/libraries/architecture/workmanager/migrating-fb
     api "androidx.work:work-runtime:$version_workmanager" // api as needs to be init at app.OnCreate
     api "androidx.work:work-runtime-ktx:$version_workmanager" // Kotlin extensions
-
-    // Debugging:
-    api('com.google.firebase:firebase-crashlytics:17.2.1')
-    // Analytics: Enhance Crashlytics experience (real time crash-free users + breadcrumbs)
-    api 'com.google.firebase:firebase-analytics:17.5.0'
 
     api 'com.facebook.stetho:stetho:1.5.0'
     api 'com.facebook.stetho:stetho-okhttp3:1.5.0'

--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/fcm/GetFcmTokenAction.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/fcm/GetFcmTokenAction.kt
@@ -34,11 +34,11 @@ class GetFcmTokenAction @Inject constructor(
                 .filter { token -> token != null }
                 .map { token -> token!! }   // Just to appease Kotlin type inference
                 .first()
-                .timeout(15, TimeUnit.SECONDS)
+                .timeout(25, TimeUnit.SECONDS)
                 .replaceTypedError(TimeoutException::class.java) { getError() }
                 .doOnError { Timber.e(it) } // force-log this UserFacingError
                 .doOnError { firebaseManager.fetchFcmToken() }
-                .retry(1)
+                .retry(2)
         }
 
     private fun getError() =

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.nav_version = "2.3.1"
 
     dependencies { // Add third party gradle plugins
-        classpath 'com.google.gms:google-services:4.3.2'    // Google Services plugin
+        classpath 'com.google.gms:google-services:4.3.10'    // Google Services plugin
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.1'
 
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
@@ -80,8 +80,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 30
-        versionCode 904
-        versionName "49.4"
+        versionCode 905
+        versionName "49.5"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/
@@ -418,7 +418,7 @@ task startStaging(type: Exec, dependsOn: 'assembleStaging') {
     commandLine "${rootProject.rootDir}/tools/run-apollo.sh", "staging"
 }
 
-apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.gms.google-services' // Google Services plugin
 // We should delete this as soon as we can. google services plugin introduces a dependency strict
 // checking that checks against other projects deps too. There's a conflict with
 // com.google.errorprone:error_prone_annotations. This should be fixed whenever the android deps

--- a/android/apolloui/src/development/google-services.json
+++ b/android/apolloui/src/development/google-services.json
@@ -1,43 +1,94 @@
 {
   "project_info": {
-    "project_id": "muun-debug",
     "project_number": "880007565849",
-    "name": "Muun Debug"
+    "firebase_url": "https://muun-debug.firebaseio.com",
+    "project_id": "muun-debug",
+    "storage_bucket": "muun-debug.appspot.com"
   },
   "client": [
     {
       "client_info": {
         "mobilesdk_app_id": "1:880007565849:android:95b71477f4f55308",
-        "client_id": "android:io.muun.apollo.debug",
-        "client_type": 1,
         "android_client_info": {
-          "package_name": "io.muun.apollo.debug",
-          "certificate_hash": []
+          "package_name": "io.muun.apollo.debug"
         }
       },
-      "oauth_client": [],
-      "api_key": [ { "current_key": "" } ],
+      "oauth_client": [
+        {
+          "client_id": "880007565849-39tect1mc9e6l8c05rg1vouoopnmruuq.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "io.muun.apollo.debug",
+            "certificate_hash": "be87aae76d32f68a229c48624e1e907f88ab2fb6"
+          }
+        },
+        {
+          "client_id": "880007565849-iegtr4pdrkkf0qbcu8gvm27pl64hsmro.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDrAwVipDayA8YfKkfCDW6u9CfOps1R9co"
+        }
+      ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "cloud_messaging_service": {
-          "status": 2,
-          "apns_config": []
-        },
         "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "880007565849-cgdit22naai9q1eg89e8btdao5a3cv03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "880007565849-1li9etmo362duqoai9h1pgcf72e1068c.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.muun.falcon.dev"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:880007565849:android:ef5949071c84bde7b6d088",
+        "android_client_info": {
+          "package_name": "io.muun.apollo.regtest"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "880007565849-iegtr4pdrkkf0qbcu8gvm27pl64hsmro.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC9BhDZfgz30geRHiPgFsOVrLb3obfzdmI"
         },
-        "google_signin_service": {
-          "status": 1
-        },
-        "ads_service": {
-          "status": 1
+        {
+          "current_key": "AIzaSyDrAwVipDayA8YfKkfCDW6u9CfOps1R9co"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "880007565849-cgdit22naai9q1eg89e8btdao5a3cv03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "880007565849-1li9etmo362duqoai9h1pgcf72e1068c.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.muun.falcon.dev"
+              }
+            }
+          ]
         }
       }
     }
   ],
-  "client_info": [],
-  "ARTIFACT_VERSION": "1"
+  "configuration_version": "1"
 }

--- a/android/apolloui/src/local/google-services.json
+++ b/android/apolloui/src/local/google-services.json
@@ -15,13 +15,21 @@
       },
       "oauth_client": [
         {
-          "client_id": "354157037931-qe9kgq8gtgjpiia6bjm6camnpgriovj8.apps.googleusercontent.com",
+          "client_id": "880007565849-39tect1mc9e6l8c05rg1vouoopnmruuq.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "io.muun.apollo.debug",
+            "certificate_hash": "be87aae76d32f68a229c48624e1e907f88ab2fb6"
+          }
+        },
+        {
+          "client_id": "880007565849-iegtr4pdrkkf0qbcu8gvm27pl64hsmro.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyC9BhDZfgz30geRHiPgFsOVrLb3obfzdmI"
+          "current_key": "AIzaSyDrAwVipDayA8YfKkfCDW6u9CfOps1R9co"
         }
       ],
       "services": {
@@ -32,10 +40,49 @@
               "client_type": 3
             },
             {
-              "client_id": "880007565849-tfb4sf3icqm5cuflf49nktmv31qf7m1h.apps.googleusercontent.com",
+              "client_id": "880007565849-1li9etmo362duqoai9h1pgcf72e1068c.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "com.muun.falcon"
+                "bundle_id": "com.muun.falcon.dev"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:880007565849:android:ef5949071c84bde7b6d088",
+        "android_client_info": {
+          "package_name": "io.muun.apollo.regtest"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "880007565849-iegtr4pdrkkf0qbcu8gvm27pl64hsmro.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC9BhDZfgz30geRHiPgFsOVrLb3obfzdmI"
+        },
+        {
+          "current_key": "AIzaSyDrAwVipDayA8YfKkfCDW6u9CfOps1R9co"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "880007565849-cgdit22naai9q1eg89e8btdao5a3cv03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "880007565849-1li9etmo362duqoai9h1pgcf72e1068c.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.muun.falcon.dev"
               }
             }
           ]

--- a/android/apolloui/src/main/res/values/strings.xml
+++ b/android/apolloui/src/main/res/values/strings.xml
@@ -346,7 +346,7 @@
 
 
     <!-- Generic strings -->
-    <string name="slogan">Bitcoin and lightning wallet</string>
+    <string name="slogan">Self-custodial wallet\nfor bitcoin and lightning</string>
     <string name="network_error_message">
         Can\'t connect to Muun\'s server. This is usually something temporary and self-healing. Wait
         a couple of seconds, check your Internet connection and try again. If the problem persists,

--- a/libwallet/lnurl.go
+++ b/libwallet/lnurl.go
@@ -14,7 +14,6 @@ type LNURLEvent struct {
 type LNURLEventMetadata struct {
 	Host      string
 	Invoice   string
-	RequestId string
 }
 
 const (
@@ -68,7 +67,6 @@ func LNURLWithdraw(invoiceBuilder *InvoiceBuilder, qr string, listener LNURLList
 			Metadata: &LNURLEventMetadata{
 				Host:      e.Metadata.Host,
 				Invoice:   e.Metadata.Invoice,
-				RequestId: e.Metadata.RequestId,
 			},
 		}
 		if event.Code < 100 {

--- a/libwallet/lnurl/lnurl.go
+++ b/libwallet/lnurl/lnurl.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/fiatjaf/go-lnurl"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -89,9 +87,8 @@ type Event struct {
 }
 
 type EventMetadata struct {
-	Host      string
-	Invoice   string
-	RequestId string
+	Host    string
+	Invoice string
 }
 
 var httpClient = http.Client{Timeout: 15 * time.Second}
@@ -132,14 +129,6 @@ func Withdraw(qr string, createInvoiceFunc CreateInvoiceFunction, allowUnsafe bo
 
 	// update contacting
 	notifier.Status(StatusContacting)
-
-	// add request id to enhance error reports and troubleshooting with LNURL service providers
-	requestId := uuid.New().String()
-	// Mutate the query params so we keep those the original URL had
-	query := qrUrl.Query()
-	query.Add("requestId", requestId)
-	qrUrl.RawQuery = query.Encode()
-	notifier.SetRequestId(requestId)
 
 	// start withdraw with service
 	resp, err := httpClient.Get(qrUrl.String())
@@ -192,7 +181,6 @@ func Withdraw(qr string, createInvoiceFunc CreateInvoiceFunction, allowUnsafe bo
 
 	// Mutate the query params so we keep those the original URL had
 	callbackQuery := callbackURL.Query()
-	callbackQuery.Add("requestId", requestId)
 	callbackQuery.Add("k1", wr.K1)
 	callbackQuery.Add("pr", invoice)
 	callbackURL.RawQuery = callbackQuery.Encode()
@@ -359,10 +347,6 @@ type notifier struct {
 
 func (n *notifier) SetHost(host string) {
 	n.metadata.Host = host
-}
-
-func (n *notifier) SetRequestId(requestId string) {
-	n.metadata.RequestId = requestId
 }
 
 func (n *notifier) SetInvoice(invoice string) {

--- a/libwallet/lnurl/lnurl_test.go
+++ b/libwallet/lnurl/lnurl_test.go
@@ -388,9 +388,6 @@ func TestNoRouteCheck(t *testing.T) {
 func TestExtraQueryParams(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/withdraw/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("requestId") == "" {
-			t.Fatalf("Expected non-empty requestId in query params. Got URL: %v", r.URL.String())
-		}
 		json.NewEncoder(w).Encode(&WithdrawResponse{
 			K1:                 "foobar",
 			Callback:           "http://" + r.Host + "/withdraw/complete?foo=bar",
@@ -400,9 +397,6 @@ func TestExtraQueryParams(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/withdraw/complete", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("requestId") == "" {
-			t.Fatalf("Expected non-empty requestId in query params. Got URL: %v", r.URL.String())
-		}
 		if r.URL.Query().Get("foo") != "bar" {
 			t.Fatalf("Expected foo=bar in query params. Got URL: %v", r.URL.String())
 		}


### PR DESCRIPTION
## [49.5] - 2022-06-02

### CHANGED
- Upgrade Firebase dependencies to start using BOM (Bill Of Materials). firebase-bom:30.1.0
- Upgrade Firebase Messaging as part of firebase-bom:30.1.0
- Upgrade Firebase Crashlytics as part of firebase-bom:30.1.0
- Upgrade Firebase Analtyics as part of firebase-bom:30.1.0
- Upgrade Google Services Gradle Plugin to 4.3.10
- Changed splash screen english copy
- Increased FcmToken fetch timeout and add extra retry to improve reliability in Fcm Token registration

### FIXED
- Removed extra query param requestId for lnurl withdraw requests to avoid errors with certain
LNURL service providers (e.g ln.cash)