### PR TITLE
Apollo: Release source code for 50.7

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,8 +6,29 @@ follow [https://changelog.md/](https://changelog.md/) guidelines.
 
 ## [Unreleased]
 
-## [50.6] - 2023-02-1
+## [50.7] - 2023-03-17
 
+### ADDED
+
+- Support for (non-standard) scientific notation for amount param of bitcoin uris, in order to be
+compatible with 3rd party services.
+- More background notification processing reliability improvements
+
+### CHANGED
+- Enriched tracing code and error handling of one particularly weird problem some users are having
+involving the pin lock screen and their maximum number of attempts.
+- Removed a security restriction for lnurl-withdraws that dictated that the bech32-encoded URL and
+the callback URL returned by the lnurl service had to had the same domain/host.
+- Enhanced error handling and added network retries for 3rd party integrity service.
+
+### FIXED
+
+- A problem regarding concurrent modification of a collection during initial sync.
+- A problem occurring in times of high-traffic (of the Bitcoin Network and/or of Muun services)
+when submitting a payment. Enhanced overall reliability of payment submission.
+- A problem when trying to send non-standard bitcoin uris (e.g having '?' but no query params).
+
+## [50.6] - 2023-02-1
 
 ### ADDED
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/base/HoustonIdDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/base/HoustonIdDao.java
@@ -5,9 +5,8 @@ import io.muun.apollo.lib.BuildConfig;
 import io.muun.common.utils.Preconditions;
 
 import android.database.Cursor;
+import androidx.annotation.NonNull;
 import rx.Observable;
-
-import javax.validation.constraints.NotNull;
 
 public abstract class HoustonIdDao<ModelT extends HoustonIdModel> extends BaseDao<ModelT> {
 
@@ -16,7 +15,7 @@ public abstract class HoustonIdDao<ModelT extends HoustonIdModel> extends BaseDa
     }
 
     @Override
-    public Observable<ModelT> store(@NotNull ModelT element) {
+    public Observable<ModelT> store(@NonNull ModelT element) {
 
         return Observable.defer(() -> {
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/base/HoustonUuidDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/base/HoustonUuidDao.java
@@ -5,6 +5,7 @@ import io.muun.apollo.lib.BuildConfig;
 import io.muun.common.utils.Preconditions;
 
 import android.database.Cursor;
+import androidx.annotation.NonNull;
 import rx.Observable;
 
 public abstract class HoustonUuidDao<ModelT extends HoustonUuidModel> extends BaseDao<ModelT> {
@@ -14,7 +15,7 @@ public abstract class HoustonUuidDao<ModelT extends HoustonUuidModel> extends Ba
     }
 
     @Override
-    public Observable<ModelT> store(ModelT element) {
+    public Observable<ModelT> store(@NonNull ModelT element) {
 
         return Observable.defer(() -> {
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/contact/ContactDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/contact/ContactDao.java
@@ -5,6 +5,7 @@ import io.muun.apollo.domain.model.Contact;
 import io.muun.apollo.domain.model.PublicProfile;
 import io.muun.common.crypto.hd.PublicKey;
 
+import androidx.annotation.NonNull;
 import rx.Completable;
 import rx.Observable;
 
@@ -31,7 +32,7 @@ public class ContactDao extends HoustonIdDao<Contact> {
     }
 
     @Override
-    protected void storeUnsafe(final Contact element) {
+    protected void storeUnsafe(@NonNull final Contact element) {
         final PublicKey userPublicKey = element.publicKey;
         final PublicKey muunPublicKey = element.cosigningPublicKey;
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapDao.java
@@ -4,6 +4,7 @@ import io.muun.apollo.data.db.base.HoustonUuidDao;
 import io.muun.apollo.domain.model.IncomingSwap;
 import io.muun.apollo.domain.model.Sha256Hash;
 
+import androidx.annotation.NonNull;
 import rx.Completable;
 
 import javax.inject.Inject;
@@ -26,7 +27,7 @@ public class IncomingSwapDao extends HoustonUuidDao<IncomingSwap> {
     }
 
     @Override
-    protected void storeUnsafe(final IncomingSwap element) {
+    protected void storeUnsafe(@NonNull final IncomingSwap element) {
         final Sha256Hash preimage = element.getPreimage();
         delightDb.getIncomingSwapQueries().insertIncomingSwap(
                 element.getId(),

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapHtlcDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapHtlcDao.java
@@ -4,6 +4,7 @@ import io.muun.apollo.data.db.base.HoustonUuidDao;
 import io.muun.apollo.domain.model.IncomingSwapHtlc;
 import io.muun.common.utils.Encodings;
 
+import androidx.annotation.NonNull;
 import rx.Completable;
 
 import javax.inject.Inject;
@@ -26,7 +27,7 @@ public class IncomingSwapHtlcDao extends HoustonUuidDao<IncomingSwapHtlcDb> {
     }
 
     @Override
-    protected void storeUnsafe(final IncomingSwapHtlcDb element) {
+    protected void storeUnsafe(@NonNull final IncomingSwapHtlcDb element) {
         final IncomingSwapHtlc htlc = element.getHtlc();
         final byte[] fulfillmentTx = htlc.getFulfillmentTx();
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapHtlcDb.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/incoming_swap/IncomingSwapHtlcDb.kt
@@ -10,10 +10,10 @@ import io.muun.apollo.domain.model.base.HoustonUuidModel
  * like to pass it as parameter or have the incoming swap handle the storing of the htlc. We can't
  * do that without a serious refactor, so we add this model to avoid the issue entirely.
  */
-data class IncomingSwapHtlcDb (
-        val swapHoustonUuid: String,
-        val htlc: IncomingSwapHtlc,
-): HoustonUuidModel(null, htlc.houstonUuid) {
+data class IncomingSwapHtlcDb(
+    val swapHoustonUuid: String,
+    val htlc: IncomingSwapHtlc,
+) : HoustonUuidModel(null, htlc.houstonUuid) {
 
     override var id: Long?
         get() = htlc.id

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/operation/OperationDao.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/operation/OperationDao.kt
@@ -28,9 +28,7 @@ import javax.inject.Singleton
 import javax.money.MonetaryAmount
 
 @Singleton
-open class OperationDao
-@Inject constructor()
-    : HoustonIdDao<Operation>("operations") {
+open class OperationDao @Inject constructor() : HoustonIdDao<Operation>("operations") {
 
     override fun deleteAll(): Completable {
         return Completable.fromAction { delightDb.operationQueries.deleteAll() }
@@ -74,7 +72,7 @@ open class OperationDao
         operationHid: Long,
         confirmations: Long,
         hash: String?,
-        status: OperationStatus
+        status: OperationStatus,
     ) {
         delightDb.operationQueries.updateStatus(
             confirmations, hash, status, operationHid
@@ -92,10 +90,12 @@ open class OperationDao
      * Fetches a single operation by its id.
      */
     fun fetchById(operationId: Long): Observable<Operation> {
-        return fetchOneOrFail(delightDb.operationQueries.selectById(
-            operationId,
-            this::fromAllFields
-        ))
+        return fetchOneOrFail(
+            delightDb.operationQueries.selectById(
+                operationId,
+                this::fromAllFields
+            )
+        )
             .doOnError { error: Throwable -> enhanceError(error, operationId.toString()) }
     }
 
@@ -103,10 +103,12 @@ open class OperationDao
      * Fetches a single operation by its Houston id.
      */
     fun fetchByHid(operationHid: Long): Observable<Operation> {
-        return fetchOneOrFail(delightDb.operationQueries.selectByHid(
-            operationHid,
-            this::fromAllFields
-        ))
+        return fetchOneOrFail(
+            delightDb.operationQueries.selectByHid(
+                operationHid,
+                this::fromAllFields
+            )
+        )
             .doOnError { error: Throwable -> enhanceError(error, operationHid.toString()) }
     }
 
@@ -124,10 +126,12 @@ open class OperationDao
     }
 
     open fun fetchByIncomingSwapUuid(incomingSwap: String): Observable<Operation> {
-        return fetchOneOrFail(delightDb.operationQueries.selectByIncomingSwap(
-            incomingSwap,
-            this::fromAllFields
-        ))
+        return fetchOneOrFail(
+            delightDb.operationQueries.selectByIncomingSwap(
+                incomingSwap,
+                this::fromAllFields
+            )
+        )
     }
 
     fun watchUtxoSetState(): Observable<UtxoSetState> {
@@ -141,9 +145,8 @@ open class OperationDao
 
         return Observable.zip(
             executeCount(hasRbfQuery),
-            executeCount(hasNonRbfQuery),
-            { f, s -> Pair.of(f, s) }
-        )
+            executeCount(hasNonRbfQuery)
+        ) { f, s -> Pair.of(f, s) }
             .map { pair ->
                 if (pair.fst > 0) {
                     return@map UtxoSetState.RBF
@@ -242,7 +245,7 @@ open class OperationDao
         htlcAddress: String?,
         htlcOutputAmountInSatoshis: Long?,
         htlcTxInHex: String?,
-        _htlcIncomingSwapHoustonUuid: String?
+        _htlcIncomingSwapHoustonUuid: String?,
     ): Operation {
 
         val senderProfile = if (senderProfileId != null) {

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/phone_contact/PhoneContactDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/phone_contact/PhoneContactDao.java
@@ -4,6 +4,7 @@ import io.muun.apollo.data.db.base.BaseDao;
 import io.muun.apollo.domain.model.PhoneContact;
 import io.muun.common.model.Diff;
 
+import androidx.annotation.NonNull;
 import com.squareup.sqlbrite3.BriteDatabase;
 import rx.Completable;
 import rx.Observable;
@@ -29,7 +30,7 @@ public class PhoneContactDao extends BaseDao<PhoneContact> {
     }
 
     @Override
-    protected void storeUnsafe(final PhoneContact element) {
+    protected void storeUnsafe(@NonNull final PhoneContact element) {
 
         delightDb.getPhoneContactQueries().insertPhoneContact(
                 element.getId(),
@@ -45,6 +46,7 @@ public class PhoneContactDao extends BaseDao<PhoneContact> {
 
     /**
      * Synchronize the PhoneContact table with a stream of system contacts.
+     *
      * @return Diff of phone number hashes added/deleted from the table.
      */
     public Observable<Diff<String>> syncWith(List<PhoneContact> contacts, long currentTs) {
@@ -57,20 +59,20 @@ public class PhoneContactDao extends BaseDao<PhoneContact> {
                 // First, attempt to insert all newly found phone contacts. If a contact already
                 // existed, it is ignored. The lastSeen field is set for all found contacts, new
                 // and old.
-                for (PhoneContact contact: contacts) {
+                for (PhoneContact contact : contacts) {
                     insertOrIgnore(contact);
                     updateLastSeen(contact);
                 }
 
                 // Contacts where firstSeen matches currentTs were added for the first time now.
-                for (PhoneContact newContact: selectFirstSeenAt(currentTs)) {
+                for (PhoneContact newContact : selectFirstSeenAt(currentTs)) {
                     newContact.generateHash();
                     updatePhoneHash(newContact);
                     diff.added.add(newContact.phoneNumberHash);
                 }
 
                 // Contacts where lastSeen doesn't match currentTs were removed since the last scan.
-                for (PhoneContact deletedContact: selectLastSeenNotAt(currentTs)) {
+                for (PhoneContact deletedContact : selectLastSeenNotAt(currentTs)) {
                     diff.removed.add(deletedContact.phoneNumberHash);
                 }
 

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/public_profile/PublicProfileDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/public_profile/PublicProfileDao.java
@@ -3,6 +3,7 @@ package io.muun.apollo.data.db.public_profile;
 import io.muun.apollo.data.db.base.HoustonIdDao;
 import io.muun.apollo.domain.model.PublicProfile;
 
+import androidx.annotation.NonNull;
 import rx.Completable;
 import rx.Observable;
 
@@ -26,7 +27,7 @@ public class PublicProfileDao extends HoustonIdDao<PublicProfile> {
     }
 
     @Override
-    protected void storeUnsafe(final PublicProfile element) {
+    protected void storeUnsafe(@NonNull final PublicProfile element) {
         delightDb.getPublicProfileQueries().insertPublicProfile(
                 element.getId(),
                 element.getHid(),

--- a/android/apollo/src/main/java/io/muun/apollo/data/db/submarine_swap/SubmarineSwapDao.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/db/submarine_swap/SubmarineSwapDao.java
@@ -9,6 +9,7 @@ import io.muun.common.crypto.hd.MuunAddress;
 import io.muun.common.crypto.hd.PublicKey;
 import io.muun.common.model.DebtType;
 
+import androidx.annotation.NonNull;
 import rx.Completable;
 
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ public class SubmarineSwapDao extends HoustonUuidDao<SubmarineSwap> {
     }
 
     @Override
-    protected void storeUnsafe(final SubmarineSwap swap) {
+    protected void storeUnsafe(@NonNull final SubmarineSwap swap) {
         final SubmarineSwapReceiver receiver = swap.getReceiver();
         final SubmarineSwapFundingOutput fundingOutput = swap.getFundingOutput();
         final MuunAddress userRefundAddress = fundingOutput.getUserRefundAddress();

--- a/android/apollo/src/main/java/io/muun/apollo/data/logging/Crashlytics.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/logging/Crashlytics.kt
@@ -16,15 +16,19 @@ import timber.log.Timber
 
 object Crashlytics {
 
-    private val crashlytics = FirebaseCrashlytics.getInstance()
+    private val crashlytics = if (LoggingContext.sendToCrashlytics) {
+        FirebaseCrashlytics.getInstance()
+    } else {
+        null
+    }
 
     /**
      * Set up Crashlytics metadata.
      */
     @JvmStatic
     fun configure(email: String?, userId: String) {
-        crashlytics.setUserId(userId)
-        crashlytics.setCustomKey("email", email ?: "unknown")
+        crashlytics?.setUserId(userId)
+        crashlytics?.setCustomKey("email", email ?: "unknown")
 
         // TODO: use setUserEmail, and grab Houston session UUID to attach it
     }
@@ -36,7 +40,7 @@ object Crashlytics {
     @JvmStatic
     fun logBreadcrumb(breadcrumb: String) {
         Timber.d("Breadcrumb: $breadcrumb")
-        crashlytics.log(breadcrumb);
+        crashlytics?.log(breadcrumb);
     }
 
     /**
@@ -49,15 +53,15 @@ object Crashlytics {
             return
         }
 
-        crashlytics.setCustomKey("tag", report.tag)
-        crashlytics.setCustomKey("message", report.message)
-        crashlytics.setCustomKey("locale", LoggingContext.locale)
+        crashlytics?.setCustomKey("tag", report.tag)
+        crashlytics?.setCustomKey("message", report.message)
+        crashlytics?.setCustomKey("locale", LoggingContext.locale)
 
         for (entry in report.metadata.entries) {
-            crashlytics.setCustomKey(entry.key, entry.value.toString())
+            crashlytics?.setCustomKey(entry.key, entry.value.toString())
         }
 
-        crashlytics.recordException(report.error)
+        crashlytics?.recordException(report.error)
     }
 
     /**
@@ -72,14 +76,14 @@ object Crashlytics {
         crashReportingError: Throwable,
     ) {
 
-        tag?.let { crashlytics.setCustomKey("tag", it) }
-        message?.let { crashlytics.setCustomKey("message", it) }
+        tag?.let { crashlytics?.setCustomKey("tag", it) }
+        message?.let { crashlytics?.setCustomKey("message", it) }
 
         if (originalError != null) {
-            crashlytics.recordException(originalError)
+            crashlytics?.recordException(originalError)
         }
 
-        crashlytics.recordException(crashReportingError)
+        crashlytics?.recordException(crashReportingError)
     }
 
     /**
@@ -89,7 +93,7 @@ object Crashlytics {
      * @see ForceCrashReportAction
      */
     fun forceReport(error: ForceCrashReportAction.ForcedCrashlyticsCall) {
-        crashlytics.recordException(error)
+        crashlytics?.recordException(error)
     }
 
     /**

--- a/android/apollo/src/main/java/io/muun/apollo/data/net/ApiObjectsMapper.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/net/ApiObjectsMapper.java
@@ -48,6 +48,7 @@ import io.muun.common.model.challenge.ChallengeSignature;
 import io.muun.common.utils.BitcoinUtils;
 import io.muun.common.utils.Encodings;
 
+import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import libwallet.MusigNonces;
 
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -194,12 +196,9 @@ public class ApiObjectsMapper {
     public ClientJson mapClient(
             final String bigQueryPseudoId,
             final boolean isRootHint,
-            final long totalInternalStorageInBytes,
-            @NonNull final List<Long> totalExternalStorageInBytes,
-            final long totalRamInBytes,
             @NonNull final String androidId,
             @NonNull final List<SystemUserInfo> systemUsersInfo,
-            @NonNull final List<String> drmClientIds
+            @NonNull final Map<String, String> drmProviderToClientId
     ) {
 
         return new ClientJson(
@@ -212,13 +211,12 @@ public class ApiObjectsMapper {
                 Locale.getDefault().toString(),
                 bigQueryPseudoId,
                 isRootHint,
-                totalInternalStorageInBytes,
-                totalExternalStorageInBytes,
-                totalRamInBytes,
                 androidId,
                 0,
-                drmClientIds,
-                mapSystemUsersInfo(systemUsersInfo)
+                mapSystemUsersInfo(systemUsersInfo),
+                drmProviderToClientId,
+                SystemClock.uptimeMillis(),
+                SystemClock.elapsedRealtime()
         );
     }
 
@@ -242,24 +240,18 @@ public class ApiObjectsMapper {
             CurrencyUnit primaryCurrency,
             String bigQueryPseudoId,
             boolean isRootHint,
-            long totalInternalStorageInBytes,
-            @NonNull List<Long> totalExternalStorageInBytes,
-            long totalRamInBytes,
             @NonNull String androidId,
             @NonNull List<SystemUserInfo> systemUsersInfo,
-            @NonNull List<String> drmClientIds
+            @NonNull Map<String, String> drmProviderToClientId
     ) {
 
         return new CreateFirstSessionJson(
                 mapClient(
                         bigQueryPseudoId,
                         isRootHint,
-                        totalInternalStorageInBytes,
-                        totalExternalStorageInBytes,
-                        totalRamInBytes,
                         androidId,
                         systemUsersInfo,
-                        drmClientIds
+                        drmProviderToClientId
                 ),
                 gcmToken,
                 primaryCurrency,
@@ -276,24 +268,18 @@ public class ApiObjectsMapper {
             String email,
             String bigQueryPseudoId,
             boolean isRootHint,
-            long totalInternalStorageInBytes,
-            @NonNull List<Long> totalExternalStorageInBytes,
-            long totalRamInBytes,
             @NonNull String androidId,
             @NonNull List<SystemUserInfo> systemUsersInfo,
-            @NonNull List<String> drmClientIds
+            @NonNull Map<String, String> drmProviderToClientId
     ) {
 
         return new CreateLoginSessionJson(
                 mapClient(
                         bigQueryPseudoId,
                         isRootHint,
-                        totalInternalStorageInBytes,
-                        totalExternalStorageInBytes,
-                        totalRamInBytes,
                         androidId,
                         systemUsersInfo,
-                        drmClientIds
+                        drmProviderToClientId
                 ),
                 gcmToken,
                 email
@@ -308,24 +294,18 @@ public class ApiObjectsMapper {
             String rcChallengePublicKeyHex,
             String bigQueryPseudoId,
             boolean isRootHint,
-            long totalInternalStorageInBytes,
-            @NonNull List<Long> totalExternalStorageInBytes,
-            long totalRamInBytes,
             @NonNull String androidId,
             @NonNull List<SystemUserInfo> systemUsersInfo,
-            @NonNull List<String> drmClientIds
+            @NonNull Map<String, String> drmProviderToClientId
     ) {
 
         return new CreateRcLoginSessionJson(
                 mapClient(
                         bigQueryPseudoId,
                         isRootHint,
-                        totalInternalStorageInBytes,
-                        totalExternalStorageInBytes,
-                        totalRamInBytes,
                         androidId,
                         systemUsersInfo,
-                        drmClientIds
+                        drmProviderToClientId
                 ),
                 gcmToken,
                 new ChallengeKeyJson(

--- a/android/apollo/src/main/java/io/muun/apollo/data/net/HoustonClient.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/net/HoustonClient.java
@@ -131,9 +131,6 @@ public class HoustonClient extends BaseClient<HoustonService> {
                 primaryCurrency,
                 bigQueryPseudoId,
                 isRootHint,
-                hardwareCapabilitiesProvider.getTotalInternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalExternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalRamInBytes(),
                 hardwareCapabilitiesProvider.getAndroidId(),
                 hardwareCapabilitiesProvider.getSystemUsersInfo(),
                 hardwareCapabilitiesProvider.getDrmClientIds()
@@ -158,9 +155,6 @@ public class HoustonClient extends BaseClient<HoustonService> {
                 email,
                 bigQueryPseudoId,
                 isRootHint,
-                hardwareCapabilitiesProvider.getTotalInternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalExternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalRamInBytes(),
                 hardwareCapabilitiesProvider.getAndroidId(),
                 hardwareCapabilitiesProvider.getSystemUsersInfo(),
                 hardwareCapabilitiesProvider.getDrmClientIds()
@@ -185,9 +179,6 @@ public class HoustonClient extends BaseClient<HoustonService> {
                 rcChallengePublicKeyHex,
                 bigQueryPseudoId,
                 isRootHint,
-                hardwareCapabilitiesProvider.getTotalInternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalExternalStorageInBytes(),
-                hardwareCapabilitiesProvider.getTotalRamInBytes(),
                 hardwareCapabilitiesProvider.getAndroidId(),
                 hardwareCapabilitiesProvider.getSystemUsersInfo(),
                 hardwareCapabilitiesProvider.getDrmClientIds()
@@ -203,7 +194,8 @@ public class HoustonClient extends BaseClient<HoustonService> {
     public Completable submitPlayIntegrityToken(final PlayIntegrityToken playIntegrityToken) {
         return getService().submitPlayIntegrityToken(new PlayIntegrityTokenJson(
                 playIntegrityToken.getToken(),
-                playIntegrityToken.getError()
+                playIntegrityToken.getError(),
+                playIntegrityToken.getCause()
         ));
     }
 
@@ -518,7 +510,6 @@ public class HoustonClient extends BaseClient<HoustonService> {
      */
     public Observable<TransactionPushed> pushTransaction(@Nullable String txHex,
                                                          long operationHid) {
-
         if (txHex != null) {
             return getService()
                     .pushTransaction(new RawTransaction(txHex), operationHid)

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/BackgroundExecutionMetricsProvider.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/BackgroundExecutionMetricsProvider.kt
@@ -29,13 +29,15 @@ class BackgroundExecutionMetricsProvider @Inject constructor(
             getBatteryHealth(),
             getBatteryDischargePrediction(),
             getBatteryStatus(),
+            hardwareCapabilitiesProvider.getTotalInternalStorageInBytes(),
             hardwareCapabilitiesProvider.getFreeInternalStorageInBytes(),
             hardwareCapabilitiesProvider.getFreeExternalStorageInBytes().toTypedArray(),
             hardwareCapabilitiesProvider.getTotalExternalStorageInBytes().toTypedArray(),
+            hardwareCapabilitiesProvider.getTotalRamInBytes(),
             hardwareCapabilitiesProvider.getFreeRamInBytes(),
             telephonyInfoProvider.dataState,
             telephonyInfoProvider.getSimStates().toTypedArray(),
-            networkInfoProvider.currentTransport
+            networkInfoProvider.currentTransport,
         )
 
     @Suppress("ArrayInDataClass")
@@ -47,9 +49,11 @@ class BackgroundExecutionMetricsProvider @Inject constructor(
         private val batteryHealth: String,
         private val batteryDischargePrediction: Long?,
         private val batteryState: String,
+        private val totalInternalStorage: Long,
         private val freeInternalStorage: Long,
         private val freeExternalStorage: Array<Long>,
         private val totalExternalStorage: Array<Long>,
+        private val totalRamStorage: Long,
         private val freeRamStorage: Long,
         private val dataState: String,
         private val simStates: Array<String>,

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/OS.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/OS.kt
@@ -99,8 +99,19 @@ object OS {
     fun supportsBatteryDischargePrediction(): Boolean =
         isAndroidSOrNewer()
 
+    /**
+     * Whether this OS supports UserManager#getUserCreationTime(UserHandle), which was added
+     * in M-6-23.
+     */
     fun supportsUserCreationTime(): Boolean =
         isAndroidMOrNewer()
+
+    /**
+     * Whether this OS supports MediaDrm#getSupportedCryptoSchemes(), which was introduced in
+     * R-11-30.
+     */
+    fun supportsGetSupportedCryptoSchemes(): Boolean =
+        isAndroidROrNewer()
 
     // PRIVATE STUFF:
 

--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityCheckAction.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityCheckAction.kt
@@ -1,0 +1,60 @@
+package io.muun.apollo.domain.action.integrity
+
+import io.muun.apollo.data.net.HoustonClient
+import io.muun.apollo.data.net.base.NetworkException
+import io.muun.apollo.data.os.execution.ExecutionTransformerFactory
+import io.muun.apollo.data.preferences.PlayIntegrityNonceRepository
+import io.muun.apollo.domain.errors.PlayIntegrityError
+import io.muun.apollo.domain.errors.UNKNOWN_ERROR
+import io.muun.apollo.domain.model.PlayIntegrityToken
+import io.muun.common.rx.ObservableFn
+import rx.Observable
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import javax.inject.Inject
+
+class GooglePlayIntegrityCheckAction @Inject constructor(
+    private val googlePlayIntegrity: GooglePlayIntegrity,
+    private val playIntegrityNonceRepo: PlayIntegrityNonceRepository,
+    private val transformerFactory: ExecutionTransformerFactory,
+    private val houstonClient: HoustonClient,
+) {
+
+    fun run(): Observable<out PlayIntegrityToken?> {
+        return Observable.defer {
+            // If we have a nonce from Houston, we make the Google Play Integrity API call
+            val nonce = playIntegrityNonceRepo.get()
+            return@defer if (nonce != null) {
+                googlePlayIntegrity.fetchIntegrityToken(nonce)
+                    .observeOn(transformerFactory.backgroundScheduler)
+                    .compose(buildRetryTransformer())
+                    .onErrorResumeNext { error ->
+                        if (error is PlayIntegrityError) {
+                            Observable.just(
+                                PlayIntegrityToken(null, error.getName(), error.getCause())
+                            )
+                        } else {
+                            Observable.just(PlayIntegrityToken(null, UNKNOWN_ERROR, error.message))
+                        }
+                    }
+                    .flatMapCompletable((houstonClient::submitPlayIntegrityToken))
+
+            } else {
+                Observable.just(null)
+            }
+        }
+    }
+
+    private fun buildRetryTransformer(): Observable.Transformer<PlayIntegrityToken, PlayIntegrityToken> {
+
+        val retryPolicy = GooglePlayIntegrityRetryPolicy(5, 4, GooglePlayIntegrity.retryableErrors)
+
+        return Observable.Transformer { observable ->
+            observable.retryWhen(retryPolicy)
+                .timeout(40, TimeUnit.SECONDS) // at least 3 attempts (5s, 10s, 20s)
+                .compose(ObservableFn.replaceTypedError(TimeoutException::class.java) {
+                    retryPolicy.lastError() ?: NetworkException(it)
+                })
+        }
+    }
+}

--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityRetryPolicy.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityRetryPolicy.kt
@@ -1,0 +1,31 @@
+package io.muun.apollo.domain.action.integrity
+
+import io.muun.apollo.domain.errors.PlayIntegrityError
+import io.muun.common.rx.ExponentialBackoffRetry
+
+class GooglePlayIntegrityRetryPolicy(
+    baseIntervalInSecs: Long,
+    maxRetries: Int,
+    private val retryErrorCodes: List<Int>,
+) : ExponentialBackoffRetry(baseIntervalInSecs, maxRetries, null) {
+
+    /**
+     * Subclasses can override this method to decide whether this strategy should retry after a
+     * specific error, or abort the sequence. By default, all errors of type {retryErrorTypes} are
+     * retried.
+     */
+    override fun shouldRetry(error: Throwable): Boolean {
+        if (error is PlayIntegrityError) {
+            return error.getCode() != null && retryErrorCodes.contains(error.getCode())
+        }
+
+        return false
+    }
+
+    /**
+     * Workaround for overriding getLastError but remove ugly Optional<> Java return value.
+     */
+    fun lastError(): Throwable? {
+        return super.getLastError().orElse(null)
+    }
+}

--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/lnurl/LnUrlWithdrawAction.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/lnurl/LnUrlWithdrawAction.kt
@@ -23,7 +23,6 @@ import rx.Observable
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import javax.validation.constraints.NotNull
 
 class LnUrlWithdrawAction @Inject constructor(
     private val keysRepo: KeysRepository,
@@ -34,7 +33,7 @@ class LnUrlWithdrawAction @Inject constructor(
 
     lateinit var paymentHash: Sha256Hash
 
-    override fun action(@NotNull lnurlContent: String): Observable<LnUrlState> =
+    override fun action(lnurlContent: String): Observable<LnUrlState> =
         Observable.defer { lnUrlWithdraw(lnurlContent) }
 
     private fun lnUrlWithdraw(lnurlContent: String): Observable<LnUrlState> =
@@ -139,16 +138,20 @@ class LnUrlWithdrawAction @Inject constructor(
                         subject.onNext(LnUrlState.Contacting(domain = event.metadata.host))
 
                     Libwallet.LNURLStatusInvoiceCreated ->
-                        subject.onNext(LnUrlState.InvoiceCreated(
-                            domain = event.metadata.host,
-                            invoice = event.metadata.invoice
-                        ))
+                        subject.onNext(
+                            LnUrlState.InvoiceCreated(
+                                domain = event.metadata.host,
+                                invoice = event.metadata.invoice
+                            )
+                        )
 
                     Libwallet.LNURLStatusReceiving ->
-                        subject.onNext(LnUrlState.Receiving(
-                            domain = event.metadata.host,
-                            invoice = event.metadata.invoice
-                        ))
+                        subject.onNext(
+                            LnUrlState.Receiving(
+                                domain = event.metadata.host,
+                                invoice = event.metadata.invoice
+                            )
+                        )
 
                     else -> {
                         // ignore

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/DrmProviderError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/DrmProviderError.kt
@@ -1,0 +1,28 @@
+package io.muun.apollo.domain.errors
+
+import android.media.MediaDrm
+import android.os.Build
+import java.util.*
+
+open class DrmProviderError(
+    providerUuid: UUID,
+    cause: Throwable,
+) : HardwareCapabilityError("mediaDRM", cause) {
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            metadata["supportedCryptoSchemes.size"] = MediaDrm.getSupportedCryptoSchemes().size
+        }
+        metadata["providerUuid"] = providerUuid.toString()
+        metadata["providerUuidVariant"] = providerUuid.variant()
+        metadata["providerUuidVersion"] = providerUuid.version()
+
+        if (providerUuid.version() != 1) {
+            metadata["timeBasedUUID"] = false
+        } else {
+            metadata["providerUuidNode"] = providerUuid.node()
+            metadata["providerUuidTimestamp"] = providerUuid.timestamp()
+            metadata["providerUuidClockSequence"] = providerUuid.clockSequence()
+        }
+    }
+}

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/InitialSyncError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/InitialSyncError.kt
@@ -1,6 +1,6 @@
 package io.muun.apollo.domain.errors
 
 class InitialSyncError(cause: Throwable) : MuunError(
-    "We couldn't load your information. Please, restart the application and try again",
+    "Error during initial loading. Suggestion: Restart the application and try again", // not user visible
     cause
 )

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/InitialSyncNetworkError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/InitialSyncNetworkError.kt
@@ -1,0 +1,6 @@
+package io.muun.apollo.domain.errors
+
+class InitialSyncNetworkError(cause: Throwable) : MuunError(
+    "Connection error during initial loading. Suggestion: Restart the application and try again", // not user visible
+    cause
+)

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/PlayIntegrityError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/PlayIntegrityError.kt
@@ -1,0 +1,40 @@
+package io.muun.apollo.domain.errors
+
+const val UNKNOWN_ERROR = "UNKNOWN_ERROR"
+
+open class PlayIntegrityError : MuunError {
+
+    constructor() : super("Google Play Integrity Error") {
+        metadata["name"] = "CANCELLED"
+        metadata["text"] = "Task was canceled"
+    }
+
+    constructor(cause: Throwable) : super("Google Play Integrity Error", cause) {
+        metadata["name"] = UNKNOWN_ERROR
+        metadata["text"] = cause.message ?: cause.toString()
+        metadata["cause"] = cause.message ?: cause.toString()
+    }
+
+    constructor(
+        errorCode: Int,
+        errorName: String,
+        errorText: String,
+        cause: Throwable,
+    ) : super("Google Play Integrity Error", cause) {
+        metadata["code"] = errorCode
+        metadata["name"] = errorName
+        metadata["text"] = errorText
+    }
+
+    fun getName(): String =
+        metadata["name"].toString()
+
+    fun getCode(): Int? =
+        metadata["code"]?.toString()?.toInt()
+
+    fun getText(): String =
+        metadata["text"].toString()
+
+    fun getCause(): String? =
+        metadata["cause"]?.toString()
+}

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/WeirdIncorrectAttemptsBugError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/WeirdIncorrectAttemptsBugError.kt
@@ -1,0 +1,19 @@
+package io.muun.apollo.domain.errors
+
+
+import io.muun.common.exception.PotentialBug
+
+class WeirdIncorrectAttemptsBugError(
+    remainingAttempts: Int,
+    maxAttempts: Int,
+) : MuunError(
+    "IncorrectAttempts, in secure storage, was found to be higher or equal than max attempts"
+), PotentialBug {
+
+    init {
+        metadata["remainingAttempts"] = remainingAttempts
+        metadata["maxAttempts"] = maxAttempts
+        metadata["incorrectAttempts"] = maxAttempts - remainingAttempts
+
+    }
+}

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/newop/PushTransactionSlowError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/newop/PushTransactionSlowError.kt
@@ -1,0 +1,5 @@
+package io.muun.apollo.domain.errors.newop
+
+import io.muun.apollo.domain.errors.UserFacingError
+
+class PushTransactionSlowError(cause: Throwable) : UserFacingError(cause)

--- a/android/apollo/src/main/java/io/muun/apollo/domain/libwallet/BitcoinUri.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/libwallet/BitcoinUri.kt
@@ -26,7 +26,7 @@ object BitcoinUri {
     }
 
     @VisibleForTesting
-    fun toString(amount: BitcoinAmount) =
+    fun toString(amount: BitcoinAmount): String =
         BitcoinUtils.satoshisToBitcoins(amount.inSatoshis)
             .number
             .numberValue(BigDecimal::class.java)

--- a/android/apollo/src/main/java/io/muun/apollo/domain/model/OperationUri.java
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/model/OperationUri.java
@@ -31,6 +31,7 @@ public class OperationUri {
     public static final String MUUN_AMOUNT = "amount";
     public static final String MUUN_CURRENCY = "currency";
     public static final String MUUN_DESCRIPTION = "message";
+    public static final String MUUN_LN_INVOICE = "lightning";
 
     /**
      * Create an OperationUri from any input String, by trying to use the other factory methods.

--- a/android/apollo/src/main/java/io/muun/apollo/domain/model/PlayIntegrityToken.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/model/PlayIntegrityToken.kt
@@ -1,3 +1,7 @@
 package io.muun.apollo.domain.model
 
-data class PlayIntegrityToken(val token: String?, val error: String?)
+data class PlayIntegrityToken(
+    val token: String?,        // Null in case of error
+    val error: String? = null, // Null in case of success
+    val cause: String? = null, // NonNull for strange errors, when error code can't be parsed
+)

--- a/android/apollo/src/main/java/io/muun/apollo/domain/model/user/User.java
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/model/user/User.java
@@ -166,7 +166,7 @@ public class User {
         }
 
         // Note: DO NOT use rateProvider.isAvailable(CurrencyUnit,CurrencyUnit). Apparently its
-        // flawed. It will (strangely) return true when there's no rate for ceratin currencies.
+        // flawed. It will (strangely) return true when there's no rate for certain currencies.
         if (rateProvider.getCurrencies().contains(targetCurrency)) {
             return targetCurrency;
         } else {

--- a/android/apollo/src/test/java/io/muun/apollo/application_lock/ApplicationLockTest.java
+++ b/android/apollo/src/test/java/io/muun/apollo/application_lock/ApplicationLockTest.java
@@ -7,9 +7,9 @@ import io.muun.apollo.data.os.secure_storage.FakeKeyStore;
 import io.muun.apollo.data.os.secure_storage.FakePreferences;
 import io.muun.apollo.data.os.secure_storage.SecureStorageProvider;
 import io.muun.apollo.domain.ApplicationLockManager;
+import io.muun.apollo.domain.errors.WeirdIncorrectAttemptsBugError;
 import io.muun.apollo.domain.selector.ChallengePublicKeySelector;
 
-import android.content.Context;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,9 +31,6 @@ public class ApplicationLockTest extends BaseTest {
     @Mock
     private ChallengePublicKeySelector challengePublicKeySel;
 
-    @Mock
-    private Context context; // Not really used in this tests
-
     private ApplicationLockManager lockManager;
 
     @Before
@@ -46,8 +43,7 @@ public class ApplicationLockTest extends BaseTest {
         lockManager = new ApplicationLockManager(
                 pinManager,
                 secureStorageProvider,
-                challengePublicKeySel,
-                context
+                challengePublicKeySel
         );
 
         when(pinManager.verifyPin(CORRECT_PIN)).thenReturn(true);
@@ -101,7 +97,7 @@ public class ApplicationLockTest extends BaseTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = WeirdIncorrectAttemptsBugError.class)
     public void errorOnZeroRemainingAttemptsWhenRecoverable() {
         doReturn(true).when(challengePublicKeySel).exists(any());
 

--- a/android/apollo/src/test/java/io/muun/apollo/data/net/ModelObjectsMapperTest.kt
+++ b/android/apollo/src/test/java/io/muun/apollo/data/net/ModelObjectsMapperTest.kt
@@ -3,7 +3,7 @@ package io.muun.apollo.data.net
 import io.muun.apollo.BaseTest
 import io.muun.apollo.data.serialization.SerializationUtils
 import io.muun.common.api.MuunFeatureJson
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ModelObjectsMapperTest : BaseTest() {

--- a/android/apollo/src/test/java/io/muun/apollo/domain/action/OperationActionsTest.java
+++ b/android/apollo/src/test/java/io/muun/apollo/domain/action/OperationActionsTest.java
@@ -20,7 +20,6 @@ import io.muun.common.crypto.hd.PrivateKey;
 import io.muun.common.crypto.hd.PublicKey;
 import io.muun.common.model.ExchangeRateProvider;
 import io.muun.common.model.OperationDirection;
-import io.muun.common.model.OperationStatus;
 import io.muun.common.utils.BitcoinUtils;
 
 import androidx.core.util.Pair;
@@ -277,7 +276,7 @@ public class OperationActionsTest extends BaseTest {
 
         assertThat(operation.getHid()).isEqualTo(createdOperation.getHid());
         assertThat(operation.hash).isEqualTo(hash);
-        assertThat(operation.status).isEqualTo(OperationStatus.SIGNED);
+//        assertThat(operation.status).isEqualTo(OperationStatus.SIGNED);
     }
 
     private Operation shallowCopy(Operation source) {

--- a/android/apollo/src/test/java/io/muun/apollo/domain/libwallet/BitcoinUriTest.kt
+++ b/android/apollo/src/test/java/io/muun/apollo/domain/libwallet/BitcoinUriTest.kt
@@ -12,7 +12,6 @@ internal class BitcoinUriTest : BaseTest() {
     @Test
     fun testBitcoinUriToString() {
 
-        val satoshisToBitcoins = BitcoinUtils.satoshisToBitcoins(19)
         val btcAmount = BitcoinAmount(
             19,
             BitcoinUtils.satoshisToBitcoins(19),

--- a/android/apollo/src/test/java/io/muun/apollo/domain/model/OperationTest.java
+++ b/android/apollo/src/test/java/io/muun/apollo/domain/model/OperationTest.java
@@ -20,12 +20,6 @@ public class OperationTest extends BaseTest {
         operation.status = OperationStatus.CREATED;
         assertThat(operation.isFailed()).isFalse();
 
-        operation.status = OperationStatus.SIGNING;
-        assertThat(operation.isFailed()).isFalse();
-
-        operation.status = OperationStatus.SIGNED;
-        assertThat(operation.isFailed()).isFalse();
-
         operation.status = OperationStatus.BROADCASTED;
         assertThat(operation.isFailed()).isFalse();
 

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -87,8 +87,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 1006
-        versionName "50.6"
+        versionCode 1007
+        versionName "50.7"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/

--- a/android/apolloui/src/androidTest/java/io/muun/apollo/domain/model/OperationUriTest.kt
+++ b/android/apolloui/src/androidTest/java/io/muun/apollo/domain/model/OperationUriTest.kt
@@ -21,7 +21,7 @@ import org.mockito.Mockito.doReturn
  * UnsatisfiedLinkError when run alone. We still can run the whole suite without problems
  * (go figure).
  */
-class OperationUriTest: BaseUnitTest() {
+class OperationUriTest : BaseUnitTest() {
 
     private val legacyAddress = "3AXHY3dJU1z9YkU5o1GKiLomCcdySZhBnj"
     private val bech32Address = "BC1QSQP0D3TY8AAA8N9J8R0D2PF3G40VN4AS9TPWY3J9R3GK5K64VX6QWPAXH2"
@@ -31,6 +31,10 @@ class OperationUriTest: BaseUnitTest() {
         "zafm00pv9sm7u57caycgn0qs52fxvkce96w4349x9pyqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rw" +
         "r3vxeje0glc7z2kxuqqngcqqyqqqqlgqqqqqeqqjq9qy9qsqwahd0wsnyxl5sr0q25pd8atey34665wh780ftht9" +
         "prm5dzdd30nhg5m3wwe2wpw04mk4ps8dz9y0px00sn7u4hrnkkwdhe7ymgupz2qpjj9v5r"
+    private val invoice100Sat = "lnbcrt1u1p3ljvqgpp58v7szdf8xzmcyfue60tqmzzhesf4t4uwa3h43k9gq4wte" +
+        "46kdlxsdqqcqzpgxqyz5vqsp5pnacd7q7agjv9h4y6lmn5atula28a8k4rmv2zxd3exnswpqsu8xq9qyyssqzmr5" +
+        "t40nl76sqdng5axwyvk9mft734xvy8v6c0qrk32s528tmd9rzkfcwytkujnmr75gq99wwnfrnny970xljq832hme" +
+        "g58n2mcnp7qp0h7gsc"
     private val lnUrl = "LNURL1DP68GURN8GHJ7MTPD9HZUUM0W46XS7RRDPSKUEM99E3K7MF0V9CXJATC9A3XZMRPDE" +
         "3K2TMVDE6HYMP0V3JHGCTFD3EN7ERPW3SN67EZG9KK7ATWWS3R5VPWXQCRQVPSX5KZYJTYYGAR2DFSXYCRYTPZGD" +
         "HKGEFZ8G3XXEZCVFJ4XSMGD9VKW63Z05Z3HXU3"
@@ -44,26 +48,12 @@ class OperationUriTest: BaseUnitTest() {
     @Test
     fun fromString() {
 
-        // TODO add support and test for taproot addresses
+        checkBitcoinUrisFor(legacyAddress)
+        checkBitcoinUrisFor(bech32Address)
+        checkBitcoinUrisFor("bc1q8j675rkzq3nn6vpg7quwhdh9q7drl8dzhh5rv9") // particular incident
+        checkBitcoinUrisFor(taprootAddress)
 
-        var uri = OperationUri.fromString(bech32Address)
-        assertTrue(uri.isBitcoin)
-        assertEquals(bech32Address, uri.bitcoinAddress.get())
-
-        uri = OperationUri.fromString("BITCOIN:$bech32Address")
-        assertTrue(uri.isBitcoin)
-        assertEquals(bech32Address, uri.bitcoinAddress.get())
-
-        uri = OperationUri.fromString(legacyAddress)
-        assertTrue(uri.isBitcoin)
-        assertEquals(legacyAddress, uri.bitcoinAddress.get())
-
-        uri = OperationUri.fromString("BiTCoIN:$legacyAddress?amount=1.2")
-        assertTrue(uri.isBitcoin)
-        assertEquals(legacyAddress, uri.bitcoinAddress.get())
-        assertEquals("1.2", uri.getParam(OperationUri.MUUN_AMOUNT).get())
-
-        uri = OperationUri.fromString(invoice)
+        var uri = OperationUri.fromString(invoice)
         assertTrue(uri.isLn)
         assertEquals(invoice, uri.lnInvoice.get())
 
@@ -78,8 +68,27 @@ class OperationUriTest: BaseUnitTest() {
         uri = OperationUri.fromString("lightning:$lnUrl")
         assertFalse(uri.isLn)
         assertEquals(lnUrl, uri.lnUrl.get())
+    }
 
-        val address = "bc1q8j675rkzq3nn6vpg7quwhdh9q7drl8dzhh5rv9"
+    private fun checkBitcoinUrisFor(address: String) {
+        var uri = OperationUri.fromString(address)
+        assertTrue(uri.isBitcoin)
+        assertEquals(address, uri.bitcoinAddress.get())
+
+        uri = OperationUri.fromString("BITCOIN:$address")
+        assertTrue(uri.isBitcoin)
+        assertEquals(address, uri.bitcoinAddress.get())
+
+        uri = OperationUri.fromString("BITCOIN:$address?")
+        assertTrue(uri.isBitcoin)
+        assertEquals(address, uri.bitcoinAddress.get())
+
+        uri = OperationUri.fromString("BiTCoIN:$address?amount=1.2")
+        assertTrue(uri.isBitcoin)
+        assertEquals(address, uri.bitcoinAddress.get())
+        assertEquals("1.2", uri.getParam(OperationUri.MUUN_AMOUNT).get())
+
+        // test case with data from recent incident
         val fee = 8
         val rbf = false
         val uriStringWithCustomParams = "bitcoin:$address?fee=$fee&rbf=$rbf"
@@ -89,37 +98,23 @@ class OperationUriTest: BaseUnitTest() {
         assertEquals(address, uri.bitcoinAddress.get())
         assertEquals(fee.toString(), uri.getParam("fee").get())
         assertEquals(rbf.toString(), uri.getParam("rbf").get())
+
+        // btcUriWithAmountAndCurrencyAndBolt11InvoiceParam
+        val unifiedQrUri = OperationUri.fromString(
+            "muun:$address?amount=0.000001&currency=btc&lightning=$invoice100Sat"
+        )
+        assertEquals(address, unifiedQrUri.bitcoinAddress.get())
+        assertEquals("0.000001", unifiedQrUri.getParam(OperationUri.MUUN_AMOUNT).get())
+        assertEquals("btc", unifiedQrUri.getParam(OperationUri.MUUN_CURRENCY).get())
+        assertEquals(invoice100Sat, unifiedQrUri.getParam(OperationUri.MUUN_LN_INVOICE).get())
     }
 
     @Test
     fun fromStringWithMuunUri() {
 
-        val btcUriWithoutAmount = OperationUri.fromString("muun:$legacyAddress")
-        assertTrue(btcUriWithoutAmount.isBitcoin)
-        assertEquals(legacyAddress, btcUriWithoutAmount.bitcoinAddress.get())
-
-        val btcUriWithAmount = OperationUri.fromString("muun:$legacyAddress?amount=1.2")
-        assertTrue(btcUriWithAmount.isBitcoin)
-        assertEquals(legacyAddress, btcUriWithAmount.bitcoinAddress.get())
-        assertEquals("1.2", btcUriWithAmount.getParam(OperationUri.MUUN_AMOUNT).get())
-
-        var btcUriWithAmountAndCurrency = OperationUri.fromString(
-            "muun:$legacyAddress?amount=1.2&currency=BTC"
-        )
-        assertTrue(btcUriWithAmountAndCurrency.isBitcoin)
-        assertEquals(legacyAddress, btcUriWithAmountAndCurrency.bitcoinAddress.get())
-        assertEquals("1.2", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_AMOUNT).get())
-        assertEquals("BTC", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_CURRENCY).get())
-
-        btcUriWithAmountAndCurrency = OperationUri.fromString(
-            "muun:$legacyAddress?amount=1.2&currency=btc"
-        )
-        assertTrue(btcUriWithAmountAndCurrency.isBitcoin)
-        assertEquals(legacyAddress, btcUriWithAmountAndCurrency.bitcoinAddress.get())
-        assertEquals("1.2", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_AMOUNT).get())
-        assertEquals("btc", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_CURRENCY).get())
-
-        // TODO add test for BOLT11_INVOICE_PARAM
+        checkMuunUrisFor(legacyAddress)
+        checkMuunUrisFor(bech32Address)
+        checkMuunUrisFor(taprootAddress)
 
         val lnUri = OperationUri.fromString("muun:$invoice")
         assertTrue(lnUri.isLn)
@@ -128,6 +123,46 @@ class OperationUriTest: BaseUnitTest() {
         val uri = OperationUri.fromString("muun:$lnUrl")
         assertFalse(uri.isLn)
         assertEquals(lnUrl, uri.lnUrl.get())
+    }
+
+    private fun checkMuunUrisFor(address: String) {
+        val btcUriWithoutAmount = OperationUri.fromString("muun:$address")
+        assertTrue(btcUriWithoutAmount.isBitcoin)
+        assertEquals(address, btcUriWithoutAmount.bitcoinAddress.get())
+
+        val btcUriEdgeCase = OperationUri.fromString("muun:$address?")
+        assertTrue(btcUriEdgeCase.isBitcoin)
+        assertEquals(address, btcUriEdgeCase.bitcoinAddress.get())
+
+        val btcUriWithAmount = OperationUri.fromString("muun:$address?amount=1.2")
+        assertTrue(btcUriWithAmount.isBitcoin)
+        assertEquals(address, btcUriWithAmount.bitcoinAddress.get())
+        assertEquals("1.2", btcUriWithAmount.getParam(OperationUri.MUUN_AMOUNT).get())
+
+        var btcUriWithAmountAndCurrency = OperationUri.fromString(
+            "muun:$address?amount=1.2&currency=BTC"
+        )
+        assertTrue(btcUriWithAmountAndCurrency.isBitcoin)
+        assertEquals(address, btcUriWithAmountAndCurrency.bitcoinAddress.get())
+        assertEquals("1.2", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_AMOUNT).get())
+        assertEquals("BTC", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_CURRENCY).get())
+
+        btcUriWithAmountAndCurrency = OperationUri.fromString(
+            "muun:$address?amount=1.2&currency=btc"
+        )
+        assertTrue(btcUriWithAmountAndCurrency.isBitcoin)
+        assertEquals(address, btcUriWithAmountAndCurrency.bitcoinAddress.get())
+        assertEquals("1.2", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_AMOUNT).get())
+        assertEquals("btc", btcUriWithAmountAndCurrency.getParam(OperationUri.MUUN_CURRENCY).get())
+
+        // btcUriWithAmountAndCurrencyAndBolt11InvoiceParam
+        val unifiedQrUri = OperationUri.fromString(
+            "muun:$address?amount=0.000001&currency=btc&lightning=$invoice100Sat"
+        )
+        assertEquals(address, unifiedQrUri.bitcoinAddress.get())
+        assertEquals("0.000001", unifiedQrUri.getParam(OperationUri.MUUN_AMOUNT).get())
+        assertEquals("btc", unifiedQrUri.getParam(OperationUri.MUUN_CURRENCY).get())
+        assertEquals(invoice100Sat, unifiedQrUri.getParam(OperationUri.MUUN_LN_INVOICE).get())
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -153,6 +188,18 @@ class OperationUriTest: BaseUnitTest() {
     @Test(expected = IllegalArgumentException::class)
     fun fromMalformed5() {
         val invalidAddress = "bc1q8j675rkzq3nn6vpg7quwhdh9g7drl8dzhh5rv9" // 9g7 should be 9q7
+        val fee = 8
+        val rbf = false
+        val uriString = "bitcoin:$invalidAddress?fee=$fee&rbf=$rbf"
+
+        val uri = OperationUri.fromString(uriString)
+        assertTrue(uri.isBitcoin)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun fromMalformed6() {
+        val invalidAddress =
+            "bc1ps0uwgdh35v9rh285nzlp9166gt20uynfut45ysupmrxcdfme5vqstsdcsm" // tsdcsm should be nakt5g
         val fee = 8
         val rbf = false
         val uriString = "bitcoin:$invalidAddress?fee=$fee&rbf=$rbf"

--- a/android/apolloui/src/androidTest/java/io/muun/apollo/domain/utils/SecureStorageProviderTest.kt
+++ b/android/apolloui/src/androidTest/java/io/muun/apollo/domain/utils/SecureStorageProviderTest.kt
@@ -34,8 +34,8 @@ class SecureStorageProviderTest {
     fun setUp() {
         context = InstrumentationRegistry.getInstrumentation().targetContext
         storage = SecureStorageProvider(
-                KeyStoreProvider(context),
-                SecureStoragePreferences(context)
+            KeyStoreProvider(context),
+            SecureStoragePreferences(context)
         )
     }
 
@@ -109,15 +109,15 @@ class SecureStorageProviderTest {
             println("testConcurrentAccess: invalidKeyException: $invalidKeyException")
 
             val others = errors.size - kpi -
-                    badPaddingException -
-                    unrecoverableKeyException -
-                    keyStoreCorruptedError -
-                    sharePrefsCorrupted -
-                    noSuchElementError -
-                    illegalBlockSizeException -
-                    invalidKeyException
+                badPaddingException -
+                unrecoverableKeyException -
+                keyStoreCorruptedError -
+                sharePrefsCorrupted -
+                noSuchElementError -
+                illegalBlockSizeException -
+                invalidKeyException
 
-            println("testConcurrentAccess: others: $others" )
+            println("testConcurrentAccess: others: $others")
 
             val first = errors.first()
 
@@ -128,5 +128,5 @@ class SecureStorageProviderTest {
     }
 
     private inline fun <reified T> howManyOfType(errors: List<Throwable>) =
-            errors.filter { it.isCausedByError<T>() }.size
+        errors.filter { it.isCausedByError<T>() }.size
 }

--- a/android/apolloui/src/main/assets/config.properties
+++ b/android/apolloui/src/main/assets/config.properties
@@ -6,6 +6,3 @@ database.version = 38
 # Network
 net.timeoutInSec = 20
 net.interceptors.stetho = true
-
-# Google Cloud Project
-googleCloud.projectNumber = 11965157440

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/MuunLockOverlay.java
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/MuunLockOverlay.java
@@ -2,6 +2,7 @@ package io.muun.apollo.presentation.ui.view;
 
 
 import io.muun.apollo.R;
+import io.muun.apollo.data.logging.Crashlytics;
 import io.muun.apollo.presentation.ui.utils.OS;
 import io.muun.common.utils.Preconditions;
 
@@ -133,6 +134,8 @@ public class MuunLockOverlay extends MuunView {
      * Report to the Overlay that an unlock attempt succeeded.
      */
     public void reportSuccess() {
+        Crashlytics.logBreadcrumb("MuunLockOverlay: reportSuccess");
+
         pinInput.setSuccess();
     }
 

--- a/common/src/main/java/io/muun/common/api/ClientJson.java
+++ b/common/src/main/java/io/muun/common/api/ClientJson.java
@@ -1,5 +1,6 @@
 package io.muun.common.api;
 
+import io.muun.common.utils.Deprecated;
 import io.muun.common.utils.Since;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -7,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -40,25 +42,28 @@ public class ClientJson {
     @Nullable // Before that ;)
     public String language;
 
-    @Since(apolloVersion = 604, falconVersion = 507) // Apollo 46.4 and Falcon 2.3.2
+    @Since(apolloVersion = 604) // Apollo 46.4 // Apollo only field
     @Nullable // Before that ;)
     public String bigQueryPseudoId;
 
     // TODO complete before releasing this
-    @Since(apolloVersion = 999) // Apollo ?
+    @Since(apolloVersion = 900) // Apollo 49 // Apollo only field
     @Nullable // Before that ;)
     public Boolean isRootHint;
 
     @Since(apolloVersion = 1003) // Apollo only field
-    @Nullable // Before that ;)
+    @Deprecated(atApolloVersion = 1007)
+    @Nullable // Before that ;) (and after deprecation)
     public Long totalInternalStorage;
 
     @Since(apolloVersion = 1003) // Apollo only field
+    @Deprecated(atApolloVersion = 1007)
     @Nullable // Before that ;)
     public List<Long> totalExternalStorage;
 
     @Since(apolloVersion = 1003)
-    @Nullable // Before that ;)
+    @Deprecated(atApolloVersion = 1007, atFalconVersion = 1012)
+    @Nullable // Before that ;) (and after deprecation)
     public Long totalRamStorage;
 
     @Since(apolloVersion = 1003) // Apollo only field
@@ -74,12 +79,25 @@ public class ClientJson {
     public Long androidCreationTimestampInMilliseconds;
 
     @Since(apolloVersion = 1005) // Apollo only field
-    @Nullable // Before that ;)
+    @Deprecated(atApolloVersion = 1007)
+    @Nullable // Before that ;) (and after deprecation)
     public List<String> drmClientIds;
+
+    @Since(apolloVersion = 1007) // Apollo only field
+    @Nullable // Before that ;)
+    public Map<String, String> drmProviderToClientId;
 
     @Since(apolloVersion = 1006) // Apollo only field
     @Nullable // Before that ;)
     public List<AndroidSystemUserInfoJson> androidSystemUsersInfo;
+
+    @Since(apolloVersion = 1007) // Apollo only field // Apollo 50.7
+    @Nullable // Before that ;)
+    public Long androidElapsedRealtimeAtSessionCreationInMillis;
+
+    @Since(apolloVersion = 1007) // Apollo only field // Apollo 50.7
+    @Nullable // Before that ;)
+    public Long androidUptimeAtSessionCreationInMillis;
 
     /**
      * Json constructor.
@@ -100,13 +118,13 @@ public class ClientJson {
                       @Nullable final String language,
                       @Nullable final String bigQueryPseudoId,
                       @Nullable final Boolean isRootHint,
-                      @Nullable Long totalInternalStorage,
-                      @Nullable List<Long> totalExternalStorage,
-                      @Nullable Long totalRamStorage,
                       @Nullable String androidId,
-                      long androidCreationTimestampInMilliseconds,
-                      List<String> drmClientIds,
-                      @Nullable List<AndroidSystemUserInfoJson> systemUsersInfo
+                      final long androidCreationTimestampInMilliseconds,
+                      @Nullable List<AndroidSystemUserInfoJson> systemUsersInfo,
+                      @SuppressWarnings("NullableProblems")
+                      final Map<String, String> drmProviderClientIds,
+                      final long androidElapsedRealtimeAtSessionCreationInMillis,
+                      final long androidUptimeAtSessionCreationInMillis
     ) {
         this.type = type;
         this.buildType = buildType;
@@ -117,12 +135,13 @@ public class ClientJson {
         this.language = language;
         this.bigQueryPseudoId = bigQueryPseudoId;
         this.isRootHint = isRootHint;
-        this.totalInternalStorage = totalInternalStorage;
-        this.totalExternalStorage = totalExternalStorage;
-        this.totalRamStorage = totalRamStorage;
         this.androidId = androidId;
         this.androidCreationTimestampInMilliseconds = androidCreationTimestampInMilliseconds;
-        this.drmClientIds = drmClientIds;
+        this.drmClientIds = null;
         this.androidSystemUsersInfo = systemUsersInfo;
+        this.drmProviderToClientId = drmProviderClientIds;
+        this.androidElapsedRealtimeAtSessionCreationInMillis =
+                androidElapsedRealtimeAtSessionCreationInMillis;
+        this.androidUptimeAtSessionCreationInMillis = androidUptimeAtSessionCreationInMillis;
     }
 }

--- a/common/src/main/java/io/muun/common/api/PlayIntegrityTokenJson.java
+++ b/common/src/main/java/io/muun/common/api/PlayIntegrityTokenJson.java
@@ -16,10 +16,17 @@ public class PlayIntegrityTokenJson {
     public String token;
 
     /**
-     * The error code returned by the Play Integrity API, if any. Should be present if token is not.
+     * The "name" (aka string representation) of the error code (int( returned by the Play Integrity
+     * API, if any. Should be present if token is not.
      */
     @Nullable
     public String errorCode;
+
+    /**
+     * The error cause for errors where an errorCode couldn't be parsed successfully.
+     */
+    @Nullable
+    public String errorCause;
 
     /**
      * JSON constructor.
@@ -30,8 +37,13 @@ public class PlayIntegrityTokenJson {
     /**
      * Apollo constructor.
      */
-    public PlayIntegrityTokenJson(@Nullable String token, @Nullable String errorCode) {
+    public PlayIntegrityTokenJson(
+            @Nullable String token,
+            @Nullable String errorCode,
+            @Nullable String errorCause
+    ) {
         this.token = token;
         this.errorCode = errorCode;
+        this.errorCause = errorCause;
     }
 }

--- a/common/src/main/java/io/muun/common/api/error/ErrorCode.java
+++ b/common/src/main/java/io/muun/common/api/error/ErrorCode.java
@@ -225,9 +225,6 @@ public enum ErrorCode {
     INCOMING_SWAP_ALREADY_FULFILLED(
             2074, StatusCode.CLIENT_FAILURE, "The incoming swap is already fulfilled"
     ),
-    REPEATED_USERS_IN_FRAUD_LABELS(
-            2083, StatusCode.CLIENT_FAILURE, "Repeated users in request parameters"
-    ),
 
     // error responses
     @Deprecated
@@ -308,18 +305,6 @@ public enum ErrorCode {
             2082, StatusCode.CLIENT_FAILURE, "No client found for owner"
     ),
 
-    // unexpected errors
-    CLIENT_DISCONNECTED(
-            1005, StatusCode.CLIENT_FAILURE, "Client disconnected during stream processing"
-    ),
-    @Deprecated(atApolloVersion = 19)
-    FACEBOOK_UNAVAILABLE(
-            2003, StatusCode.CLIENT_FAILURE, "Facebook unavailable"
-    ),
-    USER_LOCK_TIMEOUT(
-            2029, StatusCode.SERVER_FAILURE, "User lock timeout"
-    ),
-
     // email errors
     EMAIL_LINK_INVALID(
             5001, StatusCode.CLIENT_FAILURE, "Invalid link"
@@ -329,63 +314,6 @@ public enum ErrorCode {
     ),
     EMAIL_NOT_REGISTERED(
             5003, StatusCode.CLIENT_FAILURE, "Email not registered"
-    ),
-
-    // hardware wallet erorrs
-    HARDWARE_WALLET_NOT_FOUND(
-            6000, StatusCode.CLIENT_FAILURE, "Device not found"
-    ),
-    HARDWARE_WALLET_ALREADY_OWNED(
-            6001, StatusCode.CLIENT_FAILURE, "Device already owned by another User"
-    ),
-
-    // beam errors
-    SESSION_NOT_FOUND(
-            7000, StatusCode.CLIENT_FAILURE, "Requested session wasn't found"
-    ),
-    NOTIFICATION_NOT_FOUND(
-            7001, StatusCode.CLIENT_FAILURE, "Requested notification wasn't found"
-    ),
-    CHANNEL_ALREADY_EXISTS(
-            7002, StatusCode.CLIENT_FAILURE, "Requested channel UUID is already taken"
-    ),
-    CLOSED_CHANNEL(
-            7003, StatusCode.CLIENT_FAILURE, "The channel has been closed"
-    ),
-    CHANNEL_NOT_FOUND(
-            7004, StatusCode.CLIENT_FAILURE, "Requested channel wasn't found"
-    ),
-
-    // relay errors
-    ILLEGAL_PAIRING_STATE(
-            9001, StatusCode.CLIENT_FAILURE, "Illegal pairing state: the session is uninitialized"
-    ),
-    INVALID_CHANNEL_ID(
-            9002, StatusCode.CLIENT_FAILURE, "Invalid chanel uuid"
-    ),
-    INVALID_SESSION_ID(
-            9003, StatusCode.CLIENT_FAILURE, "Invalid session uuid"
-    ),
-    INVALID_NOTIFICATION_ID(
-            9004, StatusCode.CLIENT_FAILURE, "Invalid notification uuid"
-    ),
-
-    // hubble errors
-    @Deprecated
-    STALE_MEMPOOL(
-            8000, StatusCode.SERVER_FAILURE, "Mempool not present or too old"
-    ),
-    @Deprecated
-    INVALID_BLOCK_HASH(
-            8001, StatusCode.SERVER_FAILURE, "Invalid block hash"
-    ),
-
-    // electrum server errors
-    ELECTRUM_SERVER_UNRESPONSIVE(
-            8002, StatusCode.SERVER_FAILURE, "Electrum server returned empty response"
-    ),
-    ELECTRUM_SERVER_CONNECTION_ERROR(
-            8003, StatusCode.SERVER_FAILURE, "Electrum server connection error"
     ),
 
     // swapper errors
@@ -476,164 +404,6 @@ public enum ErrorCode {
     ),
     INVALID_DERIVATION_PATH(
             2125, StatusCode.CLIENT_FAILURE, "Derivation path is invalid"
-    ),
-
-    // exchangehub errors
-    MISSING_INVOICE_AMOUNT(
-            8150, StatusCode.CLIENT_FAILURE, "No amount was provided to fulfill the invoice"
-    ),
-    EXPIRED_INVOICE(
-            8151, StatusCode.CLIENT_FAILURE, "Invoice provided is already expired"
-    ),
-    MISMATCHED_AMOUNTS(
-            8152, StatusCode.CLIENT_FAILURE, "Invoice and manually provided amounts don't match"
-    ),
-    CLIENT_NODES_NOT_FOUND(
-            8153, StatusCode.CLIENT_FAILURE, "There isn't track of any client lightning node"
-    ),
-    PAYMENT_REQUEST_NOT_FOUND(
-            8154, StatusCode.CLIENT_FAILURE, "Payment request with provided uuid wasn't found"
-    ),
-    PAYMENT_REQUEST_ALREADY_PAID(
-            8155, StatusCode.CLIENT_FAILURE, "Payment request already paid"
-    ),
-    ROUTE_NOT_FOUND(
-            8156, StatusCode.CLIENT_FAILURE, "Payment route with provided uuid wasn't found"
-    ),
-    REPORT_MISSING_DATA(
-            8157, StatusCode.CLIENT_FAILURE, "Provided report is missing data"
-    ),
-    REPORT_ILLEGAL_STATE_TRANSITION(
-            8158, StatusCode.CLIENT_FAILURE, "Report implies an invalid route state transition"
-    ),
-    INVALID_PREIMAGE(
-            8159, StatusCode.CLIENT_FAILURE, "Provided preimage doesn't match the payment hash"
-    ),
-    PAYMENT_REQUEST_ALREADY_STARTED(
-            8160, StatusCode.CLIENT_FAILURE, "Payment request already started"
-    ),
-    PAYMENT_REQUEST_NOT_STARTED(
-            8161, StatusCode.CLIENT_FAILURE, "Payment request not started"
-    ),
-    INVALID_NETWORK(
-            8162, StatusCode.CLIENT_FAILURE, "Invalid network"
-    ),
-
-    // rebalancer errors
-    PLAN_NOT_FOUND(
-            8200, StatusCode.CLIENT_FAILURE, "There's no plan with that UUID"
-    ),
-
-    // funder errors
-    NOT_ENOUGH_FUNDS(
-            8300, StatusCode.SERVER_FAILURE, "Not enough funds in wallet"
-    ),
-
-    // syncer errors
-    ADDRESS_NOT_FOUND(
-            10000, StatusCode.CLIENT_FAILURE, "There's no address with that raw serialization"
-    ),
-    PAYMENT_NOT_FOUND(
-            10001, StatusCode.CLIENT_FAILURE, "There's no payment with that UUID"
-    ),
-    INCOMPATIBLE_ADDRESS_METADATA(
-            10002, StatusCode.CLIENT_FAILURE, "Address metadata doesn't match for existing address"
-    ),
-    NO_MATCHING_OUTPUT(
-            10003, StatusCode.CLIENT_FAILURE, "No output found matching the given arguments"
-    ),
-    TRANSACTION_NOT_FOUND(
-            10004, StatusCode.CLIENT_FAILURE, "There's no transaction with that txid"
-    ),
-    NO_MORE_NOTIFICATIONS(
-            10005, StatusCode.CLIENT_FAILURE, "Test payment notification queue is empty"
-    ),
-    OUTPUT_NOT_FOUND(
-            10006, StatusCode.CLIENT_FAILURE, "There's no output with that outpoint"
-    ),
-    NON_REPLACING_OUTPUT(
-            10007, StatusCode.CLIENT_FAILURE, "The selected output has no replacement proof"
-    ),
-    INVALID_OWNER(
-            10008, StatusCode.CLIENT_FAILURE, "Invalid debt operation owner"
-    ),
-    ILLEGAL_ADDRESS_EXPIRY(
-            10009, StatusCode.CLIENT_FAILURE, "Address is non-expirable or already resolved"
-    ),
-    DEFAULT_COLLISION(
-            10010, StatusCode.CLIENT_FAILURE, "Different default amounts for the same transaction"
-    ),
-    DEFAULT_TOO_LATE(
-            10011, StatusCode.CLIENT_FAILURE, "Defaulting after the transaction already settled"
-    ),
-    ILLEGAL_OPERATION(
-            10012, StatusCode.CLIENT_FAILURE, "Illegal debt operation creation request"
-    ),
-    OPERATION_COLLISION(
-            10013, StatusCode.CLIENT_FAILURE, "Different operation amounts for the same factors"
-    ),
-
-    // forwarder errors
-    NO_ROUTE_FOUND(
-            11000,
-            StatusCode.CLIENT_FAILURE,
-            "There isn't any route to the target destination with enough capacity"
-    ),
-    NO_PUBLIC_NODE_FOUND(
-            11001,
-            StatusCode.CLIENT_FAILURE,
-            "There isn't any known public node that can route to the target destination"
-    ),
-    AMOUNTLESS_INVOICE_NOT_SUPPORTED(
-            11002,
-            StatusCode.CLIENT_FAILURE,
-            "We don't support routing to the selected destination without an amount"
-    ),
-    INSUFFICIENT_OUTBOUND_BALANCE(
-            11003,
-            StatusCode.CLIENT_FAILURE,
-            "We don't have enough local balance to route the selected amount to its destination"
-    ),
-    ROUTING_QUOTE_NOT_FOUND(
-            11004,
-            StatusCode.CLIENT_FAILURE,
-            "There was no routing quote with that uuid"
-    ),
-    CONFLICTING_PAYMENT(
-            11005,
-            StatusCode.CLIENT_FAILURE,
-            "Payment hash being used for a different payment"
-    ),
-    NO_NODE_AVAILABLE(
-            11006,
-            StatusCode.SERVER_FAILURE,
-            "There isn't any node available to route the payment from"
-    ),
-    INVALID_NODE_PUBLIC_KEY(
-            11007,
-            StatusCode.CLIENT_FAILURE,
-            "The provided node public key is invalid"
-    ),
-    UNSUPPORTED_NODE_FEATURES(
-            11008,
-            StatusCode.CLIENT_FAILURE,
-            "The invoice has some required features unsupported by our nodes"
-    ),
-    INVOICE_ALREADY_EXPIRED(
-            11009,
-            StatusCode.CLIENT_FAILURE,
-            "The invoice is already expired so we won't execute it"
-    ),
-
-    // server errors
-    JSON_GENERATION_EXCEPTION(
-            1002, StatusCode.SERVER_FAILURE, "Error generating JSON"
-    ),
-    JSON_MISSING_CONSTRUCTOR(
-            1003, StatusCode.SERVER_FAILURE, "Missing empty constructor"
-    ),
-    UNKNOWN_ERROR(
-            100000, StatusCode.SERVER_FAILURE, "Unknown error"
     );
 
     private static Map<Integer, ErrorCode> errorCodeMap = new HashMap<>();

--- a/common/src/main/java/io/muun/common/api/error/ErrorCode.java
+++ b/common/src/main/java/io/muun/common/api/error/ErrorCode.java
@@ -225,6 +225,9 @@ public enum ErrorCode {
     INCOMING_SWAP_ALREADY_FULFILLED(
             2074, StatusCode.CLIENT_FAILURE, "The incoming swap is already fulfilled"
     ),
+    REPEATED_USERS_IN_FRAUD_LABELS(
+            2083, StatusCode.CLIENT_FAILURE, "Repeated users in request parameters"
+    ),
 
     // error responses
     @Deprecated
@@ -305,6 +308,18 @@ public enum ErrorCode {
             2082, StatusCode.CLIENT_FAILURE, "No client found for owner"
     ),
 
+    // unexpected errors
+    CLIENT_DISCONNECTED(
+            1005, StatusCode.CLIENT_FAILURE, "Client disconnected during stream processing"
+    ),
+    @Deprecated(atApolloVersion = 19)
+    FACEBOOK_UNAVAILABLE(
+            2003, StatusCode.CLIENT_FAILURE, "Facebook unavailable"
+    ),
+    USER_LOCK_TIMEOUT(
+            2029, StatusCode.SERVER_FAILURE, "User lock timeout"
+    ),
+
     // email errors
     EMAIL_LINK_INVALID(
             5001, StatusCode.CLIENT_FAILURE, "Invalid link"
@@ -314,6 +329,63 @@ public enum ErrorCode {
     ),
     EMAIL_NOT_REGISTERED(
             5003, StatusCode.CLIENT_FAILURE, "Email not registered"
+    ),
+
+    // hardware wallet erorrs
+    HARDWARE_WALLET_NOT_FOUND(
+            6000, StatusCode.CLIENT_FAILURE, "Device not found"
+    ),
+    HARDWARE_WALLET_ALREADY_OWNED(
+            6001, StatusCode.CLIENT_FAILURE, "Device already owned by another User"
+    ),
+
+    // beam errors
+    SESSION_NOT_FOUND(
+            7000, StatusCode.CLIENT_FAILURE, "Requested session wasn't found"
+    ),
+    NOTIFICATION_NOT_FOUND(
+            7001, StatusCode.CLIENT_FAILURE, "Requested notification wasn't found"
+    ),
+    CHANNEL_ALREADY_EXISTS(
+            7002, StatusCode.CLIENT_FAILURE, "Requested channel UUID is already taken"
+    ),
+    CLOSED_CHANNEL(
+            7003, StatusCode.CLIENT_FAILURE, "The channel has been closed"
+    ),
+    CHANNEL_NOT_FOUND(
+            7004, StatusCode.CLIENT_FAILURE, "Requested channel wasn't found"
+    ),
+
+    // relay errors
+    ILLEGAL_PAIRING_STATE(
+            9001, StatusCode.CLIENT_FAILURE, "Illegal pairing state: the session is uninitialized"
+    ),
+    INVALID_CHANNEL_ID(
+            9002, StatusCode.CLIENT_FAILURE, "Invalid chanel uuid"
+    ),
+    INVALID_SESSION_ID(
+            9003, StatusCode.CLIENT_FAILURE, "Invalid session uuid"
+    ),
+    INVALID_NOTIFICATION_ID(
+            9004, StatusCode.CLIENT_FAILURE, "Invalid notification uuid"
+    ),
+
+    // hubble errors
+    @Deprecated
+    STALE_MEMPOOL(
+            8000, StatusCode.SERVER_FAILURE, "Mempool not present or too old"
+    ),
+    @Deprecated
+    INVALID_BLOCK_HASH(
+            8001, StatusCode.SERVER_FAILURE, "Invalid block hash"
+    ),
+
+    // electrum server errors
+    ELECTRUM_SERVER_UNRESPONSIVE(
+            8002, StatusCode.SERVER_FAILURE, "Electrum server returned empty response"
+    ),
+    ELECTRUM_SERVER_CONNECTION_ERROR(
+            8003, StatusCode.SERVER_FAILURE, "Electrum server connection error"
     ),
 
     // swapper errors
@@ -404,6 +476,164 @@ public enum ErrorCode {
     ),
     INVALID_DERIVATION_PATH(
             2125, StatusCode.CLIENT_FAILURE, "Derivation path is invalid"
+    ),
+
+    // exchangehub errors
+    MISSING_INVOICE_AMOUNT(
+            8150, StatusCode.CLIENT_FAILURE, "No amount was provided to fulfill the invoice"
+    ),
+    EXPIRED_INVOICE(
+            8151, StatusCode.CLIENT_FAILURE, "Invoice provided is already expired"
+    ),
+    MISMATCHED_AMOUNTS(
+            8152, StatusCode.CLIENT_FAILURE, "Invoice and manually provided amounts don't match"
+    ),
+    CLIENT_NODES_NOT_FOUND(
+            8153, StatusCode.CLIENT_FAILURE, "There isn't track of any client lightning node"
+    ),
+    PAYMENT_REQUEST_NOT_FOUND(
+            8154, StatusCode.CLIENT_FAILURE, "Payment request with provided uuid wasn't found"
+    ),
+    PAYMENT_REQUEST_ALREADY_PAID(
+            8155, StatusCode.CLIENT_FAILURE, "Payment request already paid"
+    ),
+    ROUTE_NOT_FOUND(
+            8156, StatusCode.CLIENT_FAILURE, "Payment route with provided uuid wasn't found"
+    ),
+    REPORT_MISSING_DATA(
+            8157, StatusCode.CLIENT_FAILURE, "Provided report is missing data"
+    ),
+    REPORT_ILLEGAL_STATE_TRANSITION(
+            8158, StatusCode.CLIENT_FAILURE, "Report implies an invalid route state transition"
+    ),
+    INVALID_PREIMAGE(
+            8159, StatusCode.CLIENT_FAILURE, "Provided preimage doesn't match the payment hash"
+    ),
+    PAYMENT_REQUEST_ALREADY_STARTED(
+            8160, StatusCode.CLIENT_FAILURE, "Payment request already started"
+    ),
+    PAYMENT_REQUEST_NOT_STARTED(
+            8161, StatusCode.CLIENT_FAILURE, "Payment request not started"
+    ),
+    INVALID_NETWORK(
+            8162, StatusCode.CLIENT_FAILURE, "Invalid network"
+    ),
+
+    // rebalancer errors
+    PLAN_NOT_FOUND(
+            8200, StatusCode.CLIENT_FAILURE, "There's no plan with that UUID"
+    ),
+
+    // funder errors
+    NOT_ENOUGH_FUNDS(
+            8300, StatusCode.SERVER_FAILURE, "Not enough funds in wallet"
+    ),
+
+    // syncer errors
+    ADDRESS_NOT_FOUND(
+            10000, StatusCode.CLIENT_FAILURE, "There's no address with that raw serialization"
+    ),
+    PAYMENT_NOT_FOUND(
+            10001, StatusCode.CLIENT_FAILURE, "There's no payment with that UUID"
+    ),
+    INCOMPATIBLE_ADDRESS_METADATA(
+            10002, StatusCode.CLIENT_FAILURE, "Address metadata doesn't match for existing address"
+    ),
+    NO_MATCHING_OUTPUT(
+            10003, StatusCode.CLIENT_FAILURE, "No output found matching the given arguments"
+    ),
+    TRANSACTION_NOT_FOUND(
+            10004, StatusCode.CLIENT_FAILURE, "There's no transaction with that txid"
+    ),
+    NO_MORE_NOTIFICATIONS(
+            10005, StatusCode.CLIENT_FAILURE, "Test payment notification queue is empty"
+    ),
+    OUTPUT_NOT_FOUND(
+            10006, StatusCode.CLIENT_FAILURE, "There's no output with that outpoint"
+    ),
+    NON_REPLACING_OUTPUT(
+            10007, StatusCode.CLIENT_FAILURE, "The selected output has no replacement proof"
+    ),
+    INVALID_OWNER(
+            10008, StatusCode.CLIENT_FAILURE, "Invalid debt operation owner"
+    ),
+    ILLEGAL_ADDRESS_EXPIRY(
+            10009, StatusCode.CLIENT_FAILURE, "Address is non-expirable or already resolved"
+    ),
+    DEFAULT_COLLISION(
+            10010, StatusCode.CLIENT_FAILURE, "Different default amounts for the same transaction"
+    ),
+    DEFAULT_TOO_LATE(
+            10011, StatusCode.CLIENT_FAILURE, "Defaulting after the transaction already settled"
+    ),
+    ILLEGAL_OPERATION(
+            10012, StatusCode.CLIENT_FAILURE, "Illegal debt operation creation request"
+    ),
+    OPERATION_COLLISION(
+            10013, StatusCode.CLIENT_FAILURE, "Different operation amounts for the same factors"
+    ),
+
+    // forwarder errors
+    NO_ROUTE_FOUND(
+            11000,
+            StatusCode.CLIENT_FAILURE,
+            "There isn't any route to the target destination with enough capacity"
+    ),
+    NO_PUBLIC_NODE_FOUND(
+            11001,
+            StatusCode.CLIENT_FAILURE,
+            "There isn't any known public node that can route to the target destination"
+    ),
+    AMOUNTLESS_INVOICE_NOT_SUPPORTED(
+            11002,
+            StatusCode.CLIENT_FAILURE,
+            "We don't support routing to the selected destination without an amount"
+    ),
+    INSUFFICIENT_OUTBOUND_BALANCE(
+            11003,
+            StatusCode.CLIENT_FAILURE,
+            "We don't have enough local balance to route the selected amount to its destination"
+    ),
+    ROUTING_QUOTE_NOT_FOUND(
+            11004,
+            StatusCode.CLIENT_FAILURE,
+            "There was no routing quote with that uuid"
+    ),
+    CONFLICTING_PAYMENT(
+            11005,
+            StatusCode.CLIENT_FAILURE,
+            "Payment hash being used for a different payment"
+    ),
+    NO_NODE_AVAILABLE(
+            11006,
+            StatusCode.SERVER_FAILURE,
+            "There isn't any node available to route the payment from"
+    ),
+    INVALID_NODE_PUBLIC_KEY(
+            11007,
+            StatusCode.CLIENT_FAILURE,
+            "The provided node public key is invalid"
+    ),
+    UNSUPPORTED_NODE_FEATURES(
+            11008,
+            StatusCode.CLIENT_FAILURE,
+            "The invoice has some required features unsupported by our nodes"
+    ),
+    INVOICE_ALREADY_EXPIRED(
+            11009,
+            StatusCode.CLIENT_FAILURE,
+            "The invoice is already expired so we won't execute it"
+    ),
+
+    // server errors
+    JSON_GENERATION_EXCEPTION(
+            1002, StatusCode.SERVER_FAILURE, "Error generating JSON"
+    ),
+    JSON_MISSING_CONSTRUCTOR(
+            1003, StatusCode.SERVER_FAILURE, "Missing empty constructor"
+    ),
+    UNKNOWN_ERROR(
+            100000, StatusCode.SERVER_FAILURE, "Unknown error"
     );
 
     private static Map<Integer, ErrorCode> errorCodeMap = new HashMap<>();

--- a/common/src/main/java/io/muun/common/bitcoinj/BitcoinUri.java
+++ b/common/src/main/java/io/muun/common/bitcoinj/BitcoinUri.java
@@ -166,7 +166,7 @@ public class BitcoinUri {
         final String addressToken = addressSplitTokens[0];  // may be empty!
         final String[] nameValuePairTokens;
 
-        if (addressSplitTokens.length == 1) {
+        if (addressSplitTokens.length == 1 || addressSplitTokens[1].isEmpty()) {
             // Only an address is specified - use an empty '<name>=<value>' token array.
             nameValuePairTokens = new String[]{};
 

--- a/common/src/main/java/io/muun/common/model/OperationStatus.java
+++ b/common/src/main/java/io/muun/common/model/OperationStatus.java
@@ -16,11 +16,13 @@ public enum OperationStatus {
      * Operation stored both in the server an on the signing client, in the process of being
      * signed.
      */
+    @Deprecated // Long ago. Probably years. From the time we had a Transaction Draft
     SIGNING,
 
     /**
      * Operation with an associated transaction, which has been signed but not broadcasted yet.
      */
+    @Deprecated // Long ago. Probably years. From the time we had a Transaction Draft
     SIGNED,
 
     /**

--- a/libwallet/lnurl.go
+++ b/libwallet/lnurl.go
@@ -17,6 +17,7 @@ type LNURLEventMetadata struct {
 	Invoice string
 }
 
+//goland:noinspection GoUnusedConst (these are used by native code)
 const (
 	LNURLErrDecode              = lnurl.ErrDecode
 	LNURLErrUnsafeURL           = lnurl.ErrUnsafeURL


### PR DESCRIPTION
### ADDED

- Support for (non-standard) scientific notation for amount param of bitcoin uris, in order to be
compatible with 3rd party services.
- More background notification processing reliability improvements

### CHANGED
- Enriched tracing code and error handling of one particularly weird problem some users are having
involving the pin lock screen and their maximum number of attempts.
- Removed a security restriction for lnurl-withdraws that dictated that the bech32-encoded URL and
the callback URL returned by the lnurl service had to had the same domain/host.
- Enhanced error handling and added network retries for 3rd party integrity service.

### FIXED

- A problem regarding concurrent modification of a collection during initial sync.
- A problem occurring in times of high-traffic (of the Bitcoin Network and/or of Muun services)
when submitting a payment. Enhanced overall reliability of payment submission.
- A problem when trying to send non-standard bitcoin uris (e.g having '?' but no query params).