### PR TITLE
Apollo: Release source code for 50.11

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [https://changelog.md/](https://changelog.md/) guidelines.
 
 ## [Unreleased]
 
+## [50.11] - 2023-04-27
+
+### ADDED
+
+- Support for Iranian Toman (IRT) currency.
+
+### CHANGED
+
+- Added Proguard rule to avoid minifying Pair field names when serializing to json for http requests
+
+### FIXED
+
+- A problem involving concurrent access of Android Keystore that sometimes prevented users from
+succeeding in the Unlock Screen (PIN screen).
+- A problem with newly created timezones like 'America/Juarez' or 'Europe/Kyiv', solved by upgrading
+our ThreeTen Android Backport library to the newest version.
+- Receive protocol settings item selector text got wrapped on small screen devices. Now using a
+shorten version of the setting's name/label to better fit all screens.
+
 ## [50.10] - 2023-04-11
 
 ### ADDED

--- a/android/apollo/build.gradle
+++ b/android/apollo/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     // Can't use Jake Wharton's threeten lib for test. For more info see:
     // https://github.com/JakeWharton/ThreeTenABP/issues/47
-    testImplementation 'org.threeten:threetenbp:1.3.5'
+    testImplementation 'org.threeten:threetenbp:1.6.8'
     testImplementation 'br.com.six2six:fixture-factory:3.1.0'
     testImplementation 'net.sourceforge.streamsupport:streamsupport:1.5.5'
     testImplementation 'com.github.tomakehurst:wiremock-standalone:2.6.0'

--- a/android/apollo/src/main/java/io/muun/apollo/data/net/base/HttpRetryTransformer.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/net/base/HttpRetryTransformer.java
@@ -48,12 +48,13 @@ public class HttpRetryTransformer<T> implements Observable.Transformer<T, T> {
         if (networkRetryConfig != null) {
             return new ExponentialBackoffRetry(
                     networkRetryConfig.baseIntervalInMs(),
+                    TimeUnit.MILLISECONDS,
                     networkRetryConfig.count(),
                     NetworkException.class
             );
         }
 
-        return new ExponentialBackoffRetry(1, 7, NetworkException.class);
+        return new ExponentialBackoffRetry(1, TimeUnit.SECONDS, 7, NetworkException.class);
     }
 
     private ExponentialBackoffRetry buildServerRetryPolicy() {
@@ -61,11 +62,12 @@ public class HttpRetryTransformer<T> implements Observable.Transformer<T, T> {
         if (serverRetryConfig != null) {
             return new ExponentialBackoffRetry(
                     serverRetryConfig.baseIntervalInMs(),
+                    TimeUnit.MILLISECONDS,
                     serverRetryConfig.count(),
                     ServerFailureException.class
             );
         }
 
-        return new ExponentialBackoffRetry(2, 3, ServerFailureException.class);
+        return new ExponentialBackoffRetry(2, TimeUnit.SECONDS, 3, ServerFailureException.class);
     }
 }

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/HardwareCapabilitiesProvider.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/HardwareCapabilitiesProvider.kt
@@ -218,11 +218,22 @@ class HardwareCapabilitiesProvider @Inject constructor(private val context: Cont
 
             val mediaDrm = MediaDrm(drmProviderUuid)
             val deviceIdBytes = mediaDrm.getPropertyByteArray(MediaDrm.PROPERTY_DEVICE_UNIQUE_ID)
+
+            releaseMediaDRM(mediaDrm)
+
             return Encodings.bytesToHex(Hashes.sha256(deviceIdBytes))
 
         } catch (e: Exception) {
             Timber.e(DrmProviderError(drmProviderUuid, e))
             return null
+        }
+    }
+
+    private fun releaseMediaDRM(drmObject: MediaDrm) {
+        if (OS.supportsMediaDrmClose()) {
+            drmObject.close()
+        } else {
+            drmObject.release()
         }
     }
 }

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/OS.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/OS.kt
@@ -16,10 +16,26 @@ import androidx.annotation.VisibleForTesting
  */
 object OS {
 
+    /**
+     * Whether this OS supports Hardware-backed Keystore
+     * (see: https://source.android.com/docs/security/features/keystore), which was introduced in
+     * M-6-23.
+     */
+    @JvmStatic
+    fun supportsHardwareBackedKeystore(): Boolean =
+        isAndroidMOrNewer()
+
     fun supportsInstallSourceInfo(): Boolean =
         isAndroidROrNewer()
 
     fun supportsImageDecoderApi(): Boolean =
+        isAndroidPOrNewer()
+
+    /**
+     * Whether this OS supports MediaDrm#close(), which was introduced in
+     * P-9-28, deprecating MediaDrm#close().
+     */
+    fun supportsMediaDrmClose(): Boolean =
         isAndroidPOrNewer()
 
     /**

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/secure_storage/CryptographyWrapper.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/secure_storage/CryptographyWrapper.java
@@ -13,7 +13,7 @@ import javax.crypto.SecretKey;
 
 /**
  * This class purpose is trying to work around a known issue in Android 10 regarding the Keystore.
- * See: https://issuetracker.google.com/issues/147384380.
+ * See: <a href="https://issuetracker.google.com/issues/147384380">this issue</a>.
  * Also: why isn't this in Kotlin? To keep checked exceptions in some of the methods signatures.
  */
 class CryptographyWrapper {

--- a/android/apollo/src/main/java/io/muun/apollo/data/os/secure_storage/SecureStorageMode.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/os/secure_storage/SecureStorageMode.java
@@ -1,6 +1,6 @@
 package io.muun.apollo.data.os.secure_storage;
 
-import android.os.Build;
+import io.muun.apollo.data.os.OS;
 
 public enum SecureStorageMode {
     J_MODE, M_MODE;
@@ -11,8 +11,8 @@ public enum SecureStorageMode {
      * J_MODE For api levels between 19 and 22.
      */
     public static SecureStorageMode getModeForDevice() {
-        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-                ? SecureStorageMode.J_MODE
-                : SecureStorageMode.M_MODE;
+        return OS.supportsHardwareBackedKeystore()
+                ? SecureStorageMode.M_MODE
+                : SecureStorageMode.J_MODE;
     }
 }

--- a/android/apollo/src/main/java/io/muun/apollo/data/serialization/SerializationUtils.java
+++ b/android/apollo/src/main/java/io/muun/apollo/data/serialization/SerializationUtils.java
@@ -5,7 +5,7 @@ import io.muun.apollo.data.serialization.dates.MuunZonedDateTimeSerializer;
 import io.muun.apollo.data.serialization.dates.ZonedDateTimeDeserializer;
 import io.muun.apollo.data.serialization.dates.ZonedDateTimeSerializer;
 import io.muun.apollo.domain.errors.MissingCurrencyError;
-import io.muun.apollo.domain.errors.data.MuunDeserializetionError;
+import io.muun.apollo.domain.errors.data.MuunDeserializationError;
 import io.muun.apollo.domain.model.BitcoinAmount;
 import io.muun.apollo.domain.utils.DateUtils;
 import io.muun.common.dates.MuunZonedDateTime;
@@ -150,7 +150,7 @@ public final class SerializationUtils {
         try {
             return JSON_MAPPER.readValue(jsonString, jsonType);
         } catch (IOException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, jsonString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, jsonString));
         }
     }
 
@@ -164,7 +164,7 @@ public final class SerializationUtils {
         try {
             return JSON_MAPPER.readValue(jsonString, jsonType);
         } catch (IOException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, jsonString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, jsonString));
         }
     }
 
@@ -197,7 +197,7 @@ public final class SerializationUtils {
         try {
             return new BigDecimal(numberString);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, numberString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, numberString));
         }
     }
 
@@ -221,11 +221,11 @@ public final class SerializationUtils {
         } catch (UnknownCurrencyException e) {
             // In practice, only this type of error should arise.
             Timber.e(new MissingCurrencyError(e));
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, currencyString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, currencyString));
 
         } catch (MonetaryException e) {
             // This more general kind can only happen when providers are incorrectly initialized.
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, currencyString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, currencyString));
         }
     }
 
@@ -249,7 +249,7 @@ public final class SerializationUtils {
 
         final String[] parts = moneyString.split(" ");
         if (parts.length != 2) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(moneyString));
+            throw new IllegalArgumentException(new MuunDeserializationError(moneyString));
         }
 
         final BigDecimal number = deserializeBigDecimal(parts[0]);
@@ -278,7 +278,7 @@ public final class SerializationUtils {
     public static BitcoinAmount deserializeBitcoinAmount(@NotNull String string) {
         final String[] parts = string.split(";");
         if (parts.length != 3) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(string));
+            throw new IllegalArgumentException(new MuunDeserializationError(string));
         }
 
         final Long inSatoshis = Long.valueOf(parts[0]);
@@ -314,7 +314,7 @@ public final class SerializationUtils {
                     .readValue(json);
 
         } catch (IOException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, json));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, json));
         }
     }
 
@@ -344,7 +344,7 @@ public final class SerializationUtils {
                     .readValue(json);
 
         } catch (IOException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, json));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, json));
         }
     }
 
@@ -389,7 +389,7 @@ public final class SerializationUtils {
             return object;
 
         } catch (ClassNotFoundException | IOException e) {
-            throw new IllegalArgumentException(new MuunDeserializetionError(e, objectString));
+            throw new IllegalArgumentException(new MuunDeserializationError(e, objectString));
         }
     }
 

--- a/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityRetryPolicy.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/action/integrity/GooglePlayIntegrityRetryPolicy.kt
@@ -2,12 +2,13 @@ package io.muun.apollo.domain.action.integrity
 
 import io.muun.apollo.domain.errors.PlayIntegrityError
 import io.muun.common.rx.ExponentialBackoffRetry
+import java.util.concurrent.TimeUnit
 
 class GooglePlayIntegrityRetryPolicy(
     baseIntervalInSecs: Long,
     maxRetries: Int,
     private val retryErrorCodes: List<Int>,
-) : ExponentialBackoffRetry(baseIntervalInSecs, maxRetries, null) {
+) : ExponentialBackoffRetry(baseIntervalInSecs, TimeUnit.SECONDS, maxRetries, null) {
 
     /**
      * Subclasses can override this method to decide whether this strategy should retry after a

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/DrmProviderError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/DrmProviderError.kt
@@ -1,7 +1,7 @@
 package io.muun.apollo.domain.errors
 
 import android.media.MediaDrm
-import android.os.Build
+import io.muun.apollo.data.os.OS
 import java.util.*
 
 open class DrmProviderError(
@@ -10,7 +10,7 @@ open class DrmProviderError(
 ) : HardwareCapabilityError("mediaDRM", cause) {
 
     init {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (OS.supportsGetSupportedCryptoSchemes()) {
             metadata["supportedCryptoSchemes.size"] = MediaDrm.getSupportedCryptoSchemes().size
         }
         metadata["providerUuid"] = providerUuid.toString()

--- a/android/apollo/src/main/java/io/muun/apollo/domain/errors/data/MuunDeserializationError.kt
+++ b/android/apollo/src/main/java/io/muun/apollo/domain/errors/data/MuunDeserializationError.kt
@@ -3,7 +3,7 @@ package io.muun.apollo.domain.errors.data
 import io.muun.apollo.domain.errors.MuunError
 import io.muun.common.exception.PotentialBug
 
-class MuunDeserializetionError(cause: Exception, json: String?) : MuunError(cause), PotentialBug {
+class MuunDeserializationError(cause: Exception, json: String?) : MuunError(cause), PotentialBug {
 
     constructor(json: String) : this(IllegalArgumentException(), json)
 

--- a/android/apollo/src/test/java/io/muun/apollo/data/TimeZonesTest.kt
+++ b/android/apollo/src/test/java/io/muun/apollo/data/TimeZonesTest.kt
@@ -1,0 +1,24 @@
+package io.muun.apollo.data
+
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.threeten.bp.ZoneId
+
+class TimeZonesTest {
+
+    @Test
+    fun testSupportLatestTzReleases() { // Regression test?
+
+        // Test we support 2022b release of the tz code and data
+        val kievZoneId = ZoneId.of("Europe/Kyiv", ZoneId.SHORT_IDS)
+
+        // Let's assert anything/something basic
+        Assertions.assertThat(kievZoneId.id).isEqualTo("Europe/Kyiv")
+
+        // Test we support 2022g release of the tz code and data
+        val ciudadJuarezZoneId = ZoneId.of("America/Ciudad_Juarez", ZoneId.SHORT_IDS)
+
+        // Let's assert anything/something basic
+        Assertions.assertThat(ciudadJuarezZoneId.id).isEqualTo("America/Ciudad_Juarez")
+    }
+}

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -87,8 +87,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 1010
-        versionName "50.10"
+        versionCode 1011
+        versionName "50.11"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/
@@ -390,7 +390,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     // Can't use Jake Wharton's threeten lib for test. For more info see:
     // https://github.com/JakeWharton/ThreeTenABP/issues/47
-    testImplementation 'org.threeten:threetenbp:1.3.5'
+    testImplementation 'org.threeten:threetenbp:1.6.8'
     testImplementation 'br.com.six2six:fixture-factory:3.1.0'
     testImplementation 'net.sourceforge.streamsupport:streamsupport:1.5.5'
     testImplementation 'com.github.tomakehurst:wiremock-standalone:2.6.0'

--- a/android/apolloui/proguard/proguard-muun-commmons.pro
+++ b/android/apolloui/proguard/proguard-muun-commmons.pro
@@ -18,6 +18,11 @@
 -keepclassmembers class io.muun.common.model.SizeForAmount { *; }
 -keepclassmembernames class io.muun.common.model.SizeForAmount { *; }
 
+-keepnames class io.muun.common.utils.Pair
+-keep class io.muun.common.utils.Pair { *; }
+-keepclassmembers class io.muun.common.utils.Pair { *; }
+-keepclassmembernames class io.muun.common.utils.Pair { *; }
+
 -keep public enum io.muun.common.model.SessionStatus$** {
     **[] $VALUES;
     public *;

--- a/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/ReceivePreferenceItem.kt
+++ b/android/apolloui/src/main/java/io/muun/apollo/presentation/ui/view/ReceivePreferenceItem.kt
@@ -93,7 +93,7 @@ class ReceivePreferenceItem @JvmOverloads constructor(
     }
 
     private fun getBitcoinOption(): MuunPicker.Option {
-        val title = getStyledString(R.string.receive_preference_bitcoin)
+        val title = getStyledString(R.string.receive_preference_bitcoin_title)
         val description = getStyledString(R.string.receive_preference_bitcoin_desc)
 
         val status = if (current == ReceiveFormatPreference.ONCHAIN)
@@ -110,7 +110,7 @@ class ReceivePreferenceItem @JvmOverloads constructor(
     }
 
     private fun getLightningOption(): MuunPicker.Option {
-        val title = getStyledString(R.string.receive_preference_lightning)
+        val title = getStyledString(R.string.receive_preference_lightning_title)
         val description = getStyledString(R.string.receive_preference_lightning_desc)
 
         val status = if (current == ReceiveFormatPreference.LIGHTNING)

--- a/android/apolloui/src/main/res/values-es/strings.xml
+++ b/android/apolloui/src/main/res/values-es/strings.xml
@@ -1658,12 +1658,14 @@
         (<annotation link="https://bitcoinqr.dev/">más información</annotation>).
     </string>
     <string name="receive_preference_picker_title">Elige tu protocolo para recibir</string>
-    <string name="receive_preference_bitcoin">Priorizar bitcoin</string>
+    <string name="receive_preference_bitcoin">Bitcoin</string>
+    <string name="receive_preference_bitcoin_title">Priorizar bitcoin</string>
     <string name="receive_preference_bitcoin_desc">
         Mostrar primero una dirección de bitcoin. La forma más aceptada y confiable de realizar
         transacciones en bitcoin.
     </string>
-    <string name="receive_preference_lightning">Priorizar lightning</string>
+    <string name="receive_preference_lightning">Lightning</string>
+    <string name="receive_preference_lightning_title">Priorizar lightning</string>
     <string name="receive_preference_lightning_desc">
         Mostrar primero una factura de lightning. Los pagos en lightning pueden ser más rápidos y
         económicos, pero algunos servicios aún no los soportan.

--- a/android/apolloui/src/main/res/values/strings.xml
+++ b/android/apolloui/src/main/res/values/strings.xml
@@ -1604,12 +1604,14 @@
         (<annotation link="https://bitcoinqr.dev/">learn more</annotation>).
     </string>
     <string name="receive_preference_picker_title">Choose your receiving protocol</string>
-    <string name="receive_preference_bitcoin">Bitcoin first</string>
+    <string name="receive_preference_bitcoin">Bitcoin</string>
+    <string name="receive_preference_bitcoin_title">Bitcoin first</string>
     <string name="receive_preference_bitcoin_desc">
         Default to show a bitcoin address. The most widely accepted and reliable way of transacting
         in bitcoin.
     </string>
-    <string name="receive_preference_lightning">Lightning first</string>
+    <string name="receive_preference_lightning">Lightning</string>
+    <string name="receive_preference_lightning_title">Lightning first</string>
     <string name="receive_preference_lightning_desc">
         Default to show a lightning invoice. Lightning payments can be faster and cheaper, but some
         services don\'t support them yet.

--- a/android/apolloui/src/main/resources/META-INF/services/javax.money.spi.CurrencyProviderSpi
+++ b/android/apolloui/src/main/resources/META-INF/services/javax.money.spi.CurrencyProviderSpi
@@ -1,3 +1,4 @@
 io.muun.common.utils.BitcoinCurrencyProvider
+io.muun.common.utils.IrtCurrencyProvider
 org.javamoney.moneta.internal.JDKCurrencyProvider
 org.javamoney.moneta.internal.ConfigurableCurrencyUnitProvider

--- a/common/src/main/java/io/muun/common/model/Currency.java
+++ b/common/src/main/java/io/muun/common/model/Currency.java
@@ -100,6 +100,7 @@ public class Currency {
         load(new Currency("INR", "₹", "Indian Rupee", "\uD83C\uDDEE\uD83C\uDDF3"));
         load(new Currency("IQD", "ع.د", "Iraqi Dinar", "\uD83C\uDDEE\uD83C\uDDF6"));
         load(new Currency("IRR", "﷼", "Iranian Rial", "\uD83C\uDDEE\uD83C\uDDF7"));
+        load(new Currency("IRT", "تومان", "Iranian Toman", "\uD83C\uDDEE\uD83C\uDDF7"));
         load(new Currency("ISK", "kr", "Icelandic Króna", "\uD83C\uDDEE\uD83C\uDDF8"));
         load(new Currency("JMD", "J$", "Jamaican Dollar", "\uD83C\uDDEF\uD83C\uDDF2"));
         load(new Currency("JOD", "د.ا", "Jordanian Dinar", "\uD83C\uDDEF\uD83C\uDDF4"));

--- a/common/src/main/java/io/muun/common/utils/IrtCurrencyProvider.java
+++ b/common/src/main/java/io/muun/common/utils/IrtCurrencyProvider.java
@@ -1,0 +1,63 @@
+package io.muun.common.utils;
+
+import org.javamoney.moneta.CurrencyUnitBuilder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Priority;
+import javax.money.CurrencyQuery;
+import javax.money.CurrencyUnit;
+import javax.money.spi.CurrencyProviderSpi;
+
+@Priority(2000)
+public class IrtCurrencyProvider implements CurrencyProviderSpi {
+
+    private final Set<CurrencyUnit> currencies;
+
+    /**
+     * Constructor.
+     */
+    public IrtCurrencyProvider() {
+
+        final CurrencyUnit irt = CurrencyUnitBuilder.of("IRT",getClass().getSimpleName())
+                .setDefaultFractionDigits(2)
+                .build();
+
+        final Set<CurrencyUnit> currencies = new HashSet<>();
+        currencies.add(irt);
+
+        this.currencies = Collections.unmodifiableSet(currencies);
+    }
+
+    @Override
+    public String getProviderName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean isCurrencyAvailable(CurrencyQuery query) {
+
+        if (query.isEmpty()) {
+            return true;
+        }
+
+        if (query.getCurrencyCodes().contains("IRT")) {
+            return true;
+        }
+
+        return Boolean.TRUE.equals(query.getBoolean("Iranian Toman"));
+
+    }
+
+    @Override
+    public Set<CurrencyUnit> getCurrencies(CurrencyQuery query) {
+
+        if (isCurrencyAvailable(query)) {
+            return currencies;
+        }
+
+        return Collections.emptySet();
+    }
+
+}

--- a/common/src/main/resources/META-INF/services/javax.money.spi.CurrencyProviderSpi
+++ b/common/src/main/resources/META-INF/services/javax.money.spi.CurrencyProviderSpi
@@ -1,3 +1,4 @@
 io.muun.common.utils.BitcoinCurrencyProvider
+io.muun.common.utils.IrtCurrencyProvider
 org.javamoney.moneta.internal.JDKCurrencyProvider
 org.javamoney.moneta.internal.ConfigurableCurrencyUnitProvider


### PR DESCRIPTION
## [50.11] - 2023-04-27

### ADDED

- Support for Iranian Toman (IRT) currency.

### CHANGED

- Added Proguard rule to avoid minifying Pair field names when serializing to json for http requests

### FIXED

- A problem involving concurrent access of Android Keystore that sometimes prevented users from
succeeding in the Unlock Screen (PIN screen).
- A problem with newly created timezones like 'America/Juarez' or 'Europe/Kyiv', solved by upgrading
our ThreeTen Android Backport library to the newest version.
- Receive protocol settings item selector text got wrapped on small screen devices. Now using a
shorten version of the setting's name/label to better fit all screens.