### PR TITLE
Udpate github actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,32 +8,32 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+        uses: docker/setup-buildx-action@v3.0.0
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v4
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        uses: docker/build-push-action@v5
         with:
           file: android/Dockerfile
           context: .
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk
 
       - name: Upload mapping
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: mapping
           path: apk/mapping.txt

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,37 +3,50 @@ on:
   push:
     tags:
       - v*
+
+# Note: we'll reference actions by commits for 'reproducibility sakes' (we don't
+# want an action author to change the tag reference and break our reproducibility).
+
 jobs:
   build-release:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # Matches tag v3.0.0
+        # https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
+
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Matches tag v4.1.1
+        # https://github.com/actions/checkout/releases/tag/v4.1.1
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # Matches tag v5.0.0
+        # https://github.com/docker/build-push-action/releases/tag/v5.0.0
+
         with:
           file: android/Dockerfile
           context: .
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
+        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk
 
       - name: Upload mapping
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
+        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+
         with:
           name: mapping
           path: apk/mapping.txt

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,12 +5,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+        uses: docker/setup-buildx-action@v3.0.0
+
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v4
 
       # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
       - name: Validate Gradle wrapper
@@ -21,14 +22,14 @@ jobs:
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        uses: docker/build-push-action@v5
         with:
           file: android/Dockerfile
           context: .
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,35 +1,45 @@
 name: pr
 on: pull_request
+
+# Note: we'll reference actions by commits for 'reproducibility sakes' (we don't
+# want an action author to change the tag reference and break our reproducibility).
+
 jobs:
   pr:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # Matches tag v3.0.0
+        # https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
 
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Matches tag v4.1.1
+        # https://github.com/actions/checkout/releases/tag/v4.1.1
 
-      # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # Matches tag v1.0.5
+        # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # Matches tag v5.0.0
+        # https://github.com/docker/build-push-action/releases/tag/v5.0.0
+
         with:
           file: android/Dockerfile
           context: .
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
+        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk


### PR DESCRIPTION
Warnings about depreacted `save-state` and `set-output`. But also about node12 which is deprecated and will be forced to run on node16

See:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/