### PR TITLE
Apollo: Release source code for 51.8

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [https://changelog.md/](https://changelog.md/) guidelines.
 
 ## [Unreleased]
 
+## [51.8] - 2024-02-23
+
+### CHANGED
+- Made the payment address (aka payment secret) flag required in our invoices (and also
+the TLV onion as payment secret depends on it). Having the flag as optional was causing some strict
+services to block zero amount invoices from Muun. If the secret is optional, the last hop (us) can
+forward a fake sphinx without a payment secret and for 1 sat, the app will accept it since the
+secret is optional and the last hop keeps the rest of the payment. Payment secret has been widely
+adopted for quite a bit now. Major impls all require it.
+
 ## [51.6] - 2024-01-24
 
 ### FIXED

--- a/android/apolloui/build.gradle
+++ b/android/apolloui/build.gradle
@@ -91,8 +91,8 @@ android {
         applicationId "io.muun.apollo"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 1107
-        versionName "51.7"
+        versionCode 1108
+        versionName "51.8"
 
         // Needed to make sure these classes are available in the main DEX file for API 19
         // See: https://spin.atomicobject.com/2018/07/16/support-kitkat-multidex/

--- a/libwallet/incoming_swap.go
+++ b/libwallet/incoming_swap.go
@@ -124,6 +124,8 @@ func (s *IncomingSwap) Fulfill(
 		return nil, fmt.Errorf("Fulfill: missing swap htlc data")
 	}
 
+	// TODO: add debug logs (e.g debug logging capabilities in libwallet)
+
 	err := s.VerifyFulfillable(userKey, net)
 	if err != nil {
 		return nil, err
@@ -155,7 +157,7 @@ func (s *IncomingSwap) Fulfill(
 		Sphinx:              s.SphinxPacket,
 		HtlcTx:              s.Htlc.HtlcTx,
 		PaymentHash256:      s.PaymentHash,
-		SwapServerPublicKey: []byte(s.Htlc.SwapServerPublicKey),
+		SwapServerPublicKey: s.Htlc.SwapServerPublicKey,
 		ExpirationHeight:    s.Htlc.ExpirationHeight,
 		VerifyOutputAmount:  true,
 		Collect:             btcutil.Amount(s.CollectSat),


### PR DESCRIPTION
## [51.8] - 2024-02-23

### CHANGED

- Made the payment address (aka payment secret) flag required in our invoices (and also
the TLV onion as payment secret depends on it). Having the flag as optional was causing some strict
services to block zero amount invoices from Muun. If the secret is optional, the last hop (us) can 
forward a fake sphinx without a payment secret and for 1 sat, the app will accept it since the 
secret is optional and the last hop keeps the rest of the payment. Payment secret has been widely
adopted for quite a bit now. Major impls all require it. 