### PR TITLE
Update github actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,16 +36,16 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
-        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
 
         with:
           name: apk
           path: apk/apolloui-prod-release-unsigned.apk
 
       - name: Upload mapping
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
-        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
 
         with:
           name: mapping

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ jobs:
         # https://github.com/actions/checkout/releases/tag/v4.1.1
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # Matches tag v1.0.5
-        # https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.5
+        uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43 # Matches tag v3
+        # https://github.com/gradle/actions/releases/tag/v3
 
       - name: Create output dir
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,8 +37,8 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # Matches tag v3.1.3
-        # https://github.com/actions/upload-artifact/releases/tag/v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
 
         with:
           name: apk


### PR DESCRIPTION
Warnings abou node 16 deprecation and moving to node20. Also, upload artifact ation needs updating to v4, with some warning about breaking changes.

See:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
    - breaking changes; https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
    
    
see:  https://github.com/muun/apollo/actions/runs/8942644617

![image](https://github.com/muun/apollo/assets/770614/e0dc4966-8a1d-477a-84c6-0abedeeb47f4)

