### PR TITLE
Update GH Actions to latest versions, fix deprecation warning

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,6 +11,13 @@ jobs:
   build-release:
     runs-on: ubuntu-24.04
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # Matches tag v4.0.0
         # https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,23 +12,23 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # Matches tag v3.0.0
-        # https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # Matches tag v4.0.0
+        # https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
 
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Matches tag v4.1.1
-        # https://github.com/actions/checkout/releases/tag/v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # Matches tag v6.0.2
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # Matches tag v5.0.0
-        # https://github.com/docker/build-push-action/releases/tag/v5.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # Matches tag v7.1.0
+        # https://github.com/docker/build-push-action/releases/tag/v7.1.0
 
         with:
           file: android/Dockerfile
@@ -36,16 +36,16 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
-        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # Matches tag v7.0.1
+        # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
 
         with:
           name: apk
           path: apk/apolloui-prod-*-release-unsigned.apk
 
       - name: Upload mapping
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
-        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # Matches tag v7.0.1
+        # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
 
         with:
           name: mapping

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,27 +9,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # Matches tag v3.0.0
-        # https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # Matches tag v4.0.0
+        # https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
 
         with:
           buildkitd-flags: --debug
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Matches tag v4.1.1
-        # https://github.com/actions/checkout/releases/tag/v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # Matches tag v6.0.2
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43 # Matches tag v3
-        # https://github.com/gradle/actions/releases/tag/v3
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # Matches tag v6.1.0
+        # https://github.com/gradle/actions/releases/tag/v6.1.0
 
       - name: Create output dir
         run: |
           mkdir -p apk
 
       - name: Build
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # Matches tag v5.0.0
-        # https://github.com/docker/build-push-action/releases/tag/v5.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # Matches tag v7.1.0
+        # https://github.com/docker/build-push-action/releases/tag/v7.1.0
 
         with:
           file: android/Dockerfile
@@ -37,8 +37,8 @@ jobs:
           outputs: apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # Matches tag v4.3.3
-        # https://github.com/actions/upload-artifact/releases/tag/v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # Matches tag v7.0.1
+        # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
 
         with:
           name: apk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,13 @@ jobs:
   pr:
     runs-on: ubuntu-24.04
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # Matches tag v4.0.0
         # https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0


### PR DESCRIPTION
  ## Summary                                                                                                     
                                                                                                                                                                                                               
  Update all GitHub Actions in `build-release.yml` and `pr.yml` to their latest versions.                                                                                                                        
  Actions are pinned by commit SHA for reproducibility.
                                                                                                                                                                                                                 
  | Action | Old | New | Release notes |                                                                                                                                                                         
  |--------|-----|-----|---------------|                                                                                                                                                                         
  | `actions/checkout` | v4.1.1 | v6.0.2 | https://github.com/actions/checkout/releases/tag/v6.0.2 |                                                                                                             
  | `docker/setup-buildx-action` | v3.0.0 | v4.0.0 | https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0 |                                                                                         
  | `docker/build-push-action` | v5.0.0 | v7.1.0 | https://github.com/docker/build-push-action/releases/tag/v7.1.0 |                                                                                             
  | `actions/upload-artifact` | v4.3.3 | v7.0.1 | https://github.com/actions/upload-artifact/releases/tag/v7.0.1 |                                                                                               
  | `gradle/actions/wrapper-validation` | v3 | v6.1.0 | https://github.com/gradle/actions/releases/tag/v6.1.0 |                                                                                                  
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  - [x] PR workflow runs successfully on this PR                                                                                                                                                                 
  - [x] Verify a tagged build still produces the expected APK artifact    
    Checkout: https://github.com/acrespo/apollo/actions/runs/25345169695